### PR TITLE
feat(sidebar): implement trash functionality for project management

### DIFF
--- a/app/electron/main.js
+++ b/app/electron/main.js
@@ -3,7 +3,7 @@ const path = require("path");
 // Load environment variables from .env file
 require("dotenv").config({ path: path.join(__dirname, "../.env") });
 
-const { app, BrowserWindow, ipcMain, dialog } = require("electron");
+const { app, BrowserWindow, ipcMain, dialog, shell } = require("electron");
 const fs = require("fs/promises");
 const agentService = require("./agent-service");
 const autoModeService = require("./auto-mode-service");
@@ -169,6 +169,15 @@ ipcMain.handle("fs:deleteFile", async (_, filePath) => {
   }
 });
 
+ipcMain.handle("fs:trashItem", async (_, targetPath) => {
+  try {
+    await shell.trashItem(targetPath);
+    return { success: true };
+  } catch (error) {
+    return { success: false, error: error.message };
+  }
+});
+
 // App data path
 ipcMain.handle("app:getPath", (_, name) => {
   return app.getPath(name);
@@ -193,7 +202,9 @@ ipcMain.handle(
       await fs.mkdir(imagesDir, { recursive: true });
 
       // Generate unique filename with unique ID
-      const uniqueId = `${Date.now()}-${Math.random().toString(36).substring(2, 11)}`;
+      const uniqueId = `${Date.now()}-${Math.random()
+        .toString(36)
+        .substring(2, 11)}`;
       const safeName = filename.replace(/[^a-zA-Z0-9.-]/g, "_");
       const imageFilePath = path.join(imagesDir, `${uniqueId}_${safeName}`);
 

--- a/app/electron/preload.js
+++ b/app/electron/preload.js
@@ -19,6 +19,7 @@ contextBridge.exposeInMainWorld("electronAPI", {
   exists: (filePath) => ipcRenderer.invoke("fs:exists", filePath),
   stat: (filePath) => ipcRenderer.invoke("fs:stat", filePath),
   deleteFile: (filePath) => ipcRenderer.invoke("fs:deleteFile", filePath),
+  trashItem: (filePath) => ipcRenderer.invoke("fs:trashItem", filePath),
 
   // App APIs
   getPath: (name) => ipcRenderer.invoke("app:getPath", name),

--- a/app/src/lib/electron.ts
+++ b/app/src/lib/electron.ts
@@ -89,6 +89,7 @@ export interface ElectronAPI {
   exists: (filePath: string) => Promise<boolean>;
   stat: (filePath: string) => Promise<StatResult>;
   deleteFile: (filePath: string) => Promise<WriteResult>;
+  trashItem?: (filePath: string) => Promise<WriteResult>;
   getPath: (name: string) => Promise<string>;
   saveImageToTemp?: (data: string, filename: string, mimeType: string) => Promise<SaveImageResult>;
   autoMode?: AutoModeAPI;
@@ -115,6 +116,7 @@ const mockFeatures = [
 const STORAGE_KEYS = {
   PROJECTS: "automaker_projects",
   CURRENT_PROJECT: "automaker_current_project",
+  TRASHED_PROJECTS: "automaker_trashed_projects",
 } as const;
 
 // Mock file system using localStorage
@@ -332,6 +334,10 @@ export const getElectronAPI = (): ElectronAPI => {
 
     deleteFile: async (filePath: string) => {
       delete mockFileSystem[filePath];
+      return { success: true };
+    },
+
+    trashItem: async () => {
       return { success: true };
     },
 
@@ -771,6 +777,11 @@ export interface Project {
   lastOpened?: string;
 }
 
+export interface TrashedProject extends Project {
+  trashedAt: string;
+  deletedFromDisk?: boolean;
+}
+
 export const getStoredProjects = (): Project[] => {
   if (typeof window === "undefined") return [];
   const stored = localStorage.getItem(STORAGE_KEYS.PROJECTS);
@@ -811,4 +822,15 @@ export const addProject = (project: Project): void => {
 export const removeProject = (projectId: string): void => {
   const projects = getStoredProjects().filter((p) => p.id !== projectId);
   saveProjects(projects);
+};
+
+export const getStoredTrashedProjects = (): TrashedProject[] => {
+  if (typeof window === "undefined") return [];
+  const stored = localStorage.getItem(STORAGE_KEYS.TRASHED_PROJECTS);
+  return stored ? JSON.parse(stored) : [];
+};
+
+export const saveTrashedProjects = (projects: TrashedProject[]): void => {
+  if (typeof window === "undefined") return;
+  localStorage.setItem(STORAGE_KEYS.TRASHED_PROJECTS, JSON.stringify(projects));
 };

--- a/app/src/store/app-store.ts
+++ b/app/src/store/app-store.ts
@@ -1,6 +1,6 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
-import type { Project } from "@/lib/electron";
+import type { Project, TrashedProject } from "@/lib/electron";
 
 export type ViewMode =
   | "welcome"
@@ -92,6 +92,7 @@ export interface AppState {
   // Project state
   projects: Project[];
   currentProject: Project | null;
+  trashedProjects: TrashedProject[];
 
   // View state
   currentView: ViewMode;
@@ -154,6 +155,10 @@ export interface AppActions {
   setProjects: (projects: Project[]) => void;
   addProject: (project: Project) => void;
   removeProject: (projectId: string) => void;
+  moveProjectToTrash: (projectId: string) => void;
+  restoreTrashedProject: (projectId: string) => void;
+  deleteTrashedProject: (projectId: string) => void;
+  emptyTrash: () => void;
   setCurrentProject: (project: Project | null) => void;
   reorderProjects: (oldIndex: number, newIndex: number) => void;
 
@@ -216,6 +221,7 @@ export interface AppActions {
 const initialState: AppState = {
   projects: [],
   currentProject: null,
+  trashedProjects: [],
   currentView: "welcome",
   sidebarOpen: true,
   theme: "dark",
@@ -268,6 +274,82 @@ export const useAppStore = create<AppState & AppActions>()(
       removeProject: (projectId) => {
         set({ projects: get().projects.filter((p) => p.id !== projectId) });
       },
+
+      moveProjectToTrash: (projectId) => {
+        const project = get().projects.find((p) => p.id === projectId);
+        if (!project) return;
+
+        const remainingProjects = get().projects.filter(
+          (p) => p.id !== projectId
+        );
+        const existingTrash = get().trashedProjects.filter(
+          (p) => p.id !== projectId
+        );
+        const trashedProject: TrashedProject = {
+          ...project,
+          trashedAt: new Date().toISOString(),
+          deletedFromDisk: false,
+        };
+
+        const isCurrent = get().currentProject?.id === projectId;
+
+        set({
+          projects: remainingProjects,
+          trashedProjects: [trashedProject, ...existingTrash],
+          currentProject: isCurrent ? null : get().currentProject,
+          currentView: isCurrent ? "welcome" : get().currentView,
+        });
+      },
+
+      restoreTrashedProject: (projectId) => {
+        const trashed = get().trashedProjects.find((p) => p.id === projectId);
+        if (!trashed) return;
+
+        const remainingTrash = get().trashedProjects.filter(
+          (p) => p.id !== projectId
+        );
+        const existingProjects = get().projects;
+        const samePathProject = existingProjects.find(
+          (p) => p.path === trashed.path
+        );
+        const projectsWithoutId = existingProjects.filter(
+          (p) => p.id !== projectId
+        );
+
+        // If a project with the same path already exists, keep it and just remove from trash
+        if (samePathProject) {
+          set({
+            trashedProjects: remainingTrash,
+            currentProject: samePathProject,
+            currentView: "board",
+          });
+          return;
+        }
+
+        const restoredProject: Project = {
+          id: trashed.id,
+          name: trashed.name,
+          path: trashed.path,
+          lastOpened: new Date().toISOString(),
+        };
+
+        set({
+          trashedProjects: remainingTrash,
+          projects: [...projectsWithoutId, restoredProject],
+          currentProject: restoredProject,
+          currentView: "board",
+        });
+      },
+
+      deleteTrashedProject: (projectId) => {
+        set({
+          trashedProjects: get().trashedProjects.filter(
+            (p) => p.id !== projectId
+          ),
+        });
+      },
+
+      emptyTrash: () => set({ trashedProjects: [] }),
 
       reorderProjects: (oldIndex, newIndex) => {
         const projects = [...get().projects];
@@ -495,6 +577,7 @@ export const useAppStore = create<AppState & AppActions>()(
       partialize: (state) => ({
         projects: state.projects,
         currentProject: state.currentProject,
+        trashedProjects: state.trashedProjects,
         currentView: state.currentView,
         theme: state.theme,
         sidebarOpen: state.sidebarOpen,


### PR DESCRIPTION
- Added a new `trashItem` method in the Electron API to move projects to the system trash.
- Enhanced the sidebar component to include a trash button and manage trashed projects.
- Implemented functionality to restore and permanently delete projects from the trash.
- Updated the application state to track trashed projects and provide user feedback through toast notifications.

This update significantly improves project management by allowing users to easily manage deleted projects without permanent loss.

<img width="785" height="457" alt="image" src="https://github.com/user-attachments/assets/72642dc8-64b9-440d-8f26-ad52f9c976c8" />
<img width="393" height="239" alt="image" src="https://github.com/user-attachments/assets/39b73b9f-9388-41a6-8a4b-076b8c534bb3" />
<img width="354" height="222" alt="image" src="https://github.com/user-attachments/assets/d9d10574-1917-4770-be45-6cbde2fd6a1e" />


