### PR TITLE
fix: reorder audio item in settings view navigation

### DIFF
--- a/apps/app/src/components/views/settings-view.tsx
+++ b/apps/app/src/components/views/settings-view.tsx
@@ -38,8 +38,8 @@ const NAV_ITEMS = [
   { id: "api-keys", label: "API Keys", icon: Key },
   { id: "claude", label: "Claude", icon: Terminal },
   { id: "appearance", label: "Appearance", icon: Palette },
-  { id: "audio", label: "Audio", icon: Volume2 },
   { id: "keyboard", label: "Keyboard Shortcuts", icon: Settings2 },
+  { id: "audio", label: "Audio", icon: Volume2 },
   { id: "defaults", label: "Feature Defaults", icon: FlaskConical },
   { id: "danger", label: "Danger Zone", icon: Trash2 },
 ];


### PR DESCRIPTION
## fix order of sidebar items to be consistent to setting view order

### before 
<img width="1299" height="720" alt="image" src="https://github.com/user-attachments/assets/507729b1-e0d0-48ef-9f52-9d6e9f6eafd4" />

### after
<img width="1296" height="749" alt="image" src="https://github.com/user-attachments/assets/22d79d6e-8eae-4c27-9464-9bd02ec04fc5" />
