### PR TITLE
fix: add Windows support for Claude CLI detection

### DIFF
--- a/apps/server/src/routes/setup/get-claude-status.ts
+++ b/apps/server/src/routes/setup/get-claude-status.ts
@@ -39,14 +39,17 @@ export async function getClaudeStatus() {
   } catch {
     // Not in PATH, try common locations based on platform
     const commonPaths = isWindows
-      ? [
-          // Windows-specific paths
-          path.join(os.homedir(), ".local", "bin", "claude.exe"),
-          path.join(os.homedir(), "AppData", "Roaming", "npm", "claude.cmd"),
-          path.join(os.homedir(), "AppData", "Roaming", "npm", "claude"),
-          path.join(os.homedir(), ".npm-global", "bin", "claude.cmd"),
-          path.join(os.homedir(), ".npm-global", "bin", "claude"),
-        ]
+      ? (() => {
+          const appData = process.env.APPDATA || path.join(os.homedir(), "AppData", "Roaming");
+          return [
+            // Windows-specific paths
+            path.join(os.homedir(), ".local", "bin", "claude.exe"),
+            path.join(appData, "npm", "claude.cmd"),
+            path.join(appData, "npm", "claude"),
+            path.join(appData, ".npm-global", "bin", "claude.cmd"),
+            path.join(appData, ".npm-global", "bin", "claude"),
+          ];
+        })()
       : [
           // Unix (Linux/macOS) paths
           path.join(os.homedir(), ".local", "bin", "claude"),


### PR DESCRIPTION

<img width="1331" height="909" alt="image" src="https://github.com/user-attachments/assets/2812483e-db8b-476c-964c-53a0e6549a94" />


Previously, the Claude CLI detection failed on Windows due to:

1. Shell command incompatibility
   - Used 'which claude || where claude 2>/dev/null' which fails on Windows
   - 'which' doesn't exist on Windows
   - '2>/dev/null' is Unix syntax (Windows uses '2>nul')
   - Now uses platform-specific commands: 'where' on Windows, 'which' on Unix

2. Missing Windows fallback paths
   - Only checked Unix paths like ~/.local/bin/claude
   - Added Windows-specific paths:
     * %USERPROFILE%\.local\bin\claude.exe
     * %APPDATA%\npm\claude.cmd * %USERPROFILE%\.npm-global\bin\claude.cmd

3. Credentials file detection
   - Only checked for 'credentials.json'
   - Claude CLI on Windows uses '.credentials.json' (hidden file)
   - Now checks both '.credentials.json' and 'credentials.json'

Additional improvements:
- Handle 'where' command returning multiple paths (takes first match)
- Maintains full backward compatibility with Linux and macOS