### PR TITLE
feat: add forget project to remove without deleting

### DIFF
--- a/apps/app/src/components/views/settings-view.tsx
+++ b/apps/app/src/components/views/settings-view.tsx
@@ -8,6 +8,7 @@ import { NAV_ITEMS } from "./settings-view/config/navigation";
 import { SettingsHeader } from "./settings-view/components/settings-header";
 import { KeyboardMapDialog } from "./settings-view/components/keyboard-map-dialog";
 import { DeleteProjectDialog } from "./settings-view/components/delete-project-dialog";
+import { ForgetProjectDialog } from "./settings-view/components/forget-project-dialog";
 import { SettingsNavigation } from "./settings-view/components/settings-navigation";
 import { ApiKeysSection } from "./settings-view/api-keys/api-keys-section";
 import { ClaudeCliStatus } from "./settings-view/cli-status/claude-cli-status";
@@ -38,6 +39,7 @@ export function SettingsView() {
     setMuteDoneSound,
     currentProject,
     moveProjectToTrash,
+    forgetProject,
   } = useAppStore();
 
   // Convert electron Project to settings-view Project type
@@ -77,6 +79,7 @@ export function SettingsView() {
   const { activeView, navigateTo } = useSettingsView();
 
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
+  const [showForgetDialog, setShowForgetDialog] = useState(false);
   const [showKeyboardMapDialog, setShowKeyboardMapDialog] = useState(false);
 
   // Render the active section based on current view
@@ -129,6 +132,7 @@ export function SettingsView() {
           <DangerZoneSection
             project={settingsProject}
             onDeleteClick={() => setShowDeleteDialog(true)}
+            onForgetClick={() => setShowForgetDialog(true)}
           />
         );
       default:
@@ -156,7 +160,9 @@ export function SettingsView() {
 
         {/* Content Panel - Shows only the active section */}
         <div className="flex-1 overflow-y-auto p-8">
-          <div className="max-w-4xl mx-auto">{renderActiveSection()}</div>
+          <div className="max-w-4xl mx-auto">
+            {renderActiveSection()}
+          </div>
         </div>
       </div>
 
@@ -172,6 +178,14 @@ export function SettingsView() {
         onOpenChange={setShowDeleteDialog}
         project={currentProject}
         onConfirm={moveProjectToTrash}
+      />
+
+      {/* Forget Project Confirmation Dialog */}
+      <ForgetProjectDialog
+        open={showForgetDialog}
+        onOpenChange={setShowForgetDialog}
+        project={currentProject}
+        onConfirm={forgetProject}
       />
     </div>
   );

--- a/apps/app/src/components/views/settings-view/components/forget-project-dialog.tsx
+++ b/apps/app/src/components/views/settings-view/components/forget-project-dialog.tsx
@@ -1,0 +1,65 @@
+import { Folder } from "lucide-react";
+import { DeleteConfirmDialog } from "@/components/ui/delete-confirm-dialog";
+import type { Project } from "@/lib/electron";
+
+interface ForgetProjectDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  project: Project | null;
+  onConfirm: (projectId: string) => void;
+}
+
+export function ForgetProjectDialog({
+  open,
+  onOpenChange,
+  project,
+  onConfirm,
+}: ForgetProjectDialogProps) {
+  const handleConfirm = () => {
+    if (project) {
+      onConfirm(project.id);
+    }
+  };
+
+  return (
+    <DeleteConfirmDialog
+      open={open}
+      onOpenChange={onOpenChange}
+      onConfirm={handleConfirm}
+      title="Forget Project"
+      description="Are you sure you want to forget this project?"
+      confirmText="Forget Project"
+      testId="forget-project-dialog"
+      confirmTestId="confirm-forget-project"
+    >
+      {project && (
+        <>
+          <div className="flex items-center gap-3 p-4 rounded-lg bg-sidebar-accent/10 border border-sidebar-border">
+            <div className="w-10 h-10 rounded-lg bg-sidebar-accent/20 border border-sidebar-border flex items-center justify-center shrink-0">
+              <Folder className="w-5 h-5 text-brand-500" />
+            </div>
+            <div className="min-w-0">
+              <p className="font-medium text-foreground truncate">
+                {project.name}
+              </p>
+              <p className="text-xs text-muted-foreground truncate">
+                {project.path}
+              </p>
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <p className="text-sm text-muted-foreground">
+              This will remove the project from Automaker&apos;s
+              registry, but will NOT delete any files on disk.
+            </p>
+            <p className="text-sm text-muted-foreground">
+              You can add this project back later by opening it
+              again.
+            </p>
+          </div>
+        </>
+      )}
+    </DeleteConfirmDialog>
+  );
+}

--- a/apps/app/src/components/views/settings-view/danger-zone/danger-zone-section.tsx
+++ b/apps/app/src/components/views/settings-view/danger-zone/danger-zone-section.tsx
@@ -1,16 +1,18 @@
 import { Button } from "@/components/ui/button";
-import { Trash2, Folder, AlertTriangle } from "lucide-react";
+import { Trash2, Folder, AlertTriangle, EyeOff } from "lucide-react";
 import { cn } from "@/lib/utils";
 import type { Project } from "../shared/types";
 
 interface DangerZoneSectionProps {
   project: Project | null;
   onDeleteClick: () => void;
+  onForgetClick: () => void; // New: Forget project handler
 }
 
 export function DangerZoneSection({
   project,
   onDeleteClick,
+  onForgetClick,
 }: DangerZoneSectionProps) {
   if (!project) return null;
 
@@ -31,10 +33,10 @@ export function DangerZoneSection({
           <h2 className="text-lg font-semibold text-foreground tracking-tight">Danger Zone</h2>
         </div>
         <p className="text-sm text-muted-foreground/80 ml-12">
-          Permanently remove this project from Automaker.
+          Remove this project from Automaker. Choose between moving to trash or forgetting completely.
         </p>
       </div>
-      <div className="p-6">
+      <div className="p-6 space-y-4">
         <div className="flex items-center justify-between gap-4 p-4 rounded-xl bg-destructive/5 border border-destructive/10">
           <div className="flex items-center gap-3.5 min-w-0">
             <div className="w-11 h-11 rounded-xl bg-gradient-to-br from-brand-500/15 to-brand-600/10 border border-brand-500/20 flex items-center justify-center shrink-0">
@@ -49,20 +51,39 @@ export function DangerZoneSection({
               </p>
             </div>
           </div>
-          <Button
-            variant="destructive"
-            onClick={onDeleteClick}
-            data-testid="delete-project-button"
-            className={cn(
-              "shrink-0",
-              "shadow-md shadow-destructive/20 hover:shadow-lg hover:shadow-destructive/25",
-              "transition-all duration-200 ease-out",
-              "hover:scale-[1.02] active:scale-[0.98]"
-            )}
-          >
-            <Trash2 className="w-4 h-4 mr-2" />
-            Delete Project
-          </Button>
+          <div className="flex gap-2">
+            <Button
+              variant="outline"
+              onClick={onForgetClick}
+              data-testid="forget-project-button"
+              className={cn(
+                "shrink-0",
+                "border-muted-foreground/30 hover:border-muted-foreground/50",
+                "hover:bg-muted/50"
+              )}
+            >
+              <EyeOff className="w-4 h-4 mr-2" />
+              Forget
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={onDeleteClick}
+              data-testid="delete-project-button"
+              className={cn(
+                "shrink-0",
+                "shadow-md shadow-destructive/20 hover:shadow-lg hover:shadow-destructive/25",
+                "transition-all duration-200 ease-out",
+                "hover:scale-[1.02] active:scale-[0.98]"
+              )}
+            >
+              <Trash2 className="w-4 h-4 mr-2" />
+              Move to Trash
+            </Button>
+          </div>
+        </div>
+        <div className="text-xs text-muted-foreground/60 space-y-1">
+          <p>• <strong>Forget:</strong> Removes from Automaker only. Files remain untouched.</p>
+          <p>• <strong>Move to Trash:</strong> Moves to trash for later recovery or permanent deletion.</p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Added option in danger zone to forget the project instead of deleting/moving to trash. (I accidently picked a folder with dozens of projects in it and didn't want to delete it or have to restore them.)