### PR TITLE
fix: prevent infinite loop when resuming feature with existing context

### DIFF
--- a/apps/server/src/services/auto-mode-service.ts
+++ b/apps/server/src/services/auto-mode-service.ts
@@ -487,17 +487,20 @@ export class AutoModeService {
 
     try {
       // Check if feature has existing context - if so, resume instead of starting fresh
-      const hasExistingContext = await this.contextExists(
-        projectPath,
-        featureId
-      );
-      if (hasExistingContext) {
-        console.log(
-          `[AutoMode] Feature ${featureId} has existing context, resuming instead of starting fresh`
+      // Skip this check if we're already being called with a continuation prompt (from resumeFeature)
+      if (!options?.continuationPrompt) {
+        const hasExistingContext = await this.contextExists(
+          projectPath,
+          featureId
         );
-        // Remove from running features temporarily, resumeFeature will add it back
-        this.runningFeatures.delete(featureId);
-        return this.resumeFeature(projectPath, featureId, useWorktrees);
+        if (hasExistingContext) {
+          console.log(
+            `[AutoMode] Feature ${featureId} has existing context, resuming instead of starting fresh`
+          );
+          // Remove from running features temporarily, resumeFeature will add it back
+          this.runningFeatures.delete(featureId);
+          return this.resumeFeature(projectPath, featureId, useWorktrees);
+        }
       }
 
       // Emit feature start event early


### PR DESCRIPTION
## Summary
- Fix infinite loop in AutoMode when resuming features with existing context
- When `executeFeatureWithContext` calls `executeFeature` with a continuation prompt, skip the context existence check to avoid the circular call pattern:
  `executeFeature` → `resumeFeature` → `executeFeatureWithContext` → `executeFeature` (loop)

## Test plan
- [x] Verified fix locally - no more console spam
- [x] Start a feature that has existing context and verify it resumes properly without looping

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Modified behavior when using continuation prompts with existing saved contexts. The system no longer automatically resumes from a previously saved context when a continuation prompt is provided, allowing for fresh execution instead.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->