### PR TITLE
feat: add token consumption tracking per task

### DIFF
--- a/apps/server/src/providers/types.ts
+++ b/apps/server/src/providers/types.ts
@@ -49,6 +49,29 @@ export interface ContentBlock {
 }
 
 /**
+ * Token usage statistics from SDK execution
+ */
+export interface TokenUsage {
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadInputTokens: number;
+  cacheCreationInputTokens: number;
+  totalTokens: number;
+  costUSD: number;
+}
+
+/**
+ * Per-model usage breakdown from SDK result
+ */
+export interface ModelUsageData {
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadInputTokens: number;
+  cacheCreationInputTokens: number;
+  costUSD: number;
+}
+
+/**
  * Message returned by a provider (matches Claude SDK streaming format)
  */
 export interface ProviderMessage {
@@ -62,6 +85,15 @@ export interface ProviderMessage {
   result?: string;
   error?: string;
   parent_tool_use_id?: string | null;
+  // Token usage fields (present in result messages)
+  usage?: {
+    input_tokens: number;
+    output_tokens: number;
+    cache_read_input_tokens?: number;
+    cache_creation_input_tokens?: number;
+  };
+  total_cost_usd?: number;
+  modelUsage?: Record<string, ModelUsageData>;
 }
 
 /**

--- a/apps/server/src/services/feature-loader.ts
+++ b/apps/server/src/services/feature-loader.ts
@@ -11,6 +11,7 @@ import {
   getFeatureImagesDir,
   ensureAutomakerDir,
 } from "../lib/automaker-paths.js";
+import type { TokenUsage } from "../providers/types.js";
 
 export interface Feature {
   id: string;
@@ -43,6 +44,7 @@ export interface Feature {
   error?: string;
   summary?: string;
   startedAt?: string;
+  tokenUsage?: TokenUsage;
   [key: string]: unknown;  // Keep catch-all for extensibility
 }
 

--- a/apps/ui/src/components/views/board-view/components/kanban-card.tsx
+++ b/apps/ui/src/components/views/board-view/components/kanban-card.tsx
@@ -57,6 +57,7 @@ import {
   Wand2,
   Archive,
   Lock,
+  Coins,
 } from "lucide-react";
 import { CountUpTimer } from "@/components/ui/count-up-timer";
 import { getElectronAPI } from "@/lib/electron";
@@ -88,6 +89,29 @@ function formatThinkingLevel(level: ThinkingLevel | undefined): string {
     ultrathink: "Ultra",
   };
   return labels[level];
+}
+
+/**
+ * Formats token counts for compact display (e.g., 12500 -> "12.5K")
+ */
+function formatTokenCount(count: number): string {
+  if (count >= 1000000) {
+    return `${(count / 1000000).toFixed(1)}M`;
+  }
+  if (count >= 1000) {
+    return `${(count / 1000).toFixed(1)}K`;
+  }
+  return count.toString();
+}
+
+/**
+ * Formats cost for display (e.g., 0.0847 -> "$0.0847")
+ */
+function formatCost(cost: number): string {
+  if (cost < 0.01) {
+    return `$${cost.toFixed(4)}`;
+  }
+  return `$${cost.toFixed(2)}`;
 }
 
 interface KanbanCardProps {
@@ -873,6 +897,36 @@ export const KanbanCard = memo(function KanbanCard({
                       )}
                     </div>
                   )}
+                {/* Token Usage Display */}
+                {feature.tokenUsage && feature.tokenUsage.totalTokens > 0 && (
+                  <div className="flex items-center gap-2 text-[10px] text-muted-foreground/60 pt-2 border-t border-border/30">
+                    <TooltipProvider delayDuration={200}>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <span className="flex items-center gap-1 cursor-help">
+                            <Coins className="w-2.5 h-2.5 text-amber-400" />
+                            {formatTokenCount(feature.tokenUsage.totalTokens)} tokens
+                            <span className="text-amber-400/80">
+                              ({formatCost(feature.tokenUsage.costUSD)})
+                            </span>
+                          </span>
+                        </TooltipTrigger>
+                        <TooltipContent side="top" className="text-xs">
+                          <div className="space-y-1">
+                            <p>Input: {formatTokenCount(feature.tokenUsage.inputTokens)}</p>
+                            <p>Output: {formatTokenCount(feature.tokenUsage.outputTokens)}</p>
+                            {feature.tokenUsage.cacheReadInputTokens > 0 && (
+                              <p>Cache read: {formatTokenCount(feature.tokenUsage.cacheReadInputTokens)}</p>
+                            )}
+                            <p className="font-medium pt-1 border-t border-border/30">
+                              Cost: {formatCost(feature.tokenUsage.costUSD)}
+                            </p>
+                          </div>
+                        </TooltipContent>
+                      </Tooltip>
+                    </TooltipProvider>
+                  </div>
+                )}
               </>
             )}
           </div>

--- a/apps/ui/src/components/views/board-view/dialogs/agent-output-modal.tsx
+++ b/apps/ui/src/components/views/board-view/dialogs/agent-output-modal.tsx
@@ -44,6 +44,8 @@ export function AgentOutputModal({
   const autoScrollRef = useRef(true);
   const projectPathRef = useRef<string>("");
   const useWorktrees = useAppStore((state) => state.useWorktrees);
+  const features = useAppStore((state) => state.features);
+  const feature = features.find((f) => f.id === featureId);
 
   // Auto-scroll to bottom when output changes
   useEffect(() => {
@@ -387,7 +389,7 @@ export function AgentOutputModal({
                   No output yet. The agent will stream output here as it works.
                 </div>
               ) : viewMode === "parsed" ? (
-                <LogViewer output={output} />
+                <LogViewer output={output} tokenUsage={feature?.tokenUsage} />
               ) : (
                 <div className="whitespace-pre-wrap break-words text-zinc-300">
                   {output}

--- a/apps/ui/src/store/app-store.ts
+++ b/apps/ui/src/store/app-store.ts
@@ -278,6 +278,16 @@ export interface AIProfile {
   icon?: string; // Optional icon name from lucide
 }
 
+// Token usage statistics for tracking API costs per task
+export interface TokenUsage {
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadInputTokens: number;
+  cacheCreationInputTokens: number;
+  totalTokens: number;
+  costUSD: number;
+}
+
 export interface Feature {
   id: string;
   category: string;
@@ -305,6 +315,7 @@ export interface Feature {
   planningMode?: PlanningMode; // Planning mode for this feature
   planSpec?: PlanSpec; // Generated spec/plan data
   requirePlanApproval?: boolean; // Whether to pause and require manual approval before implementation
+  tokenUsage?: TokenUsage; // Token consumption tracking for this task
 }
 
 // Parsed task from spec (for spec and full planning modes)


### PR DESCRIPTION
- Add TokenUsage interface to track input/output tokens and cost
- Capture usage from Claude SDK result messages in auto-mode-service
- Accumulate token usage across multiple streams and follow-up sessions
- Store token usage in feature.json for persistence
- Display token count and cost on Kanban cards with tooltip breakdown
- Add token usage summary header in log viewer

## Resolve
-Closes #166 

## Preview:
<img width="1433" height="830" alt="image" src="https://github.com/user-attachments/assets/aca1f3e5-4cf4-48c8-ba17-c9a6dbdfe171" />
<img width="1430" height="836" alt="image" src="https://github.com/user-attachments/assets/f333a8d6-fbf9-4a19-a257-67d0f7792314" />
<img width="1427" height="836" alt="image" src="https://github.com/user-attachments/assets/3f388a90-9fe8-46c4-a31a-fc7ecace362d" />
