### PR TITLE
fix(init): show Playwright browser download progress

### DIFF
--- a/init.mjs
+++ b/init.mjs
@@ -291,17 +291,26 @@ async function main() {
   // Install Playwright browsers from apps/ui where @playwright/test is installed
   log('Checking Playwright browsers...', 'yellow');
   try {
-    await new Promise((resolve) => {
+    const exitCode = await new Promise((resolve) => {
       const playwright = crossSpawn(
         'npx',
         ['playwright', 'install', 'chromium'],
         { stdio: 'inherit', cwd: path.join(__dirname, 'apps', 'ui') }
       );
-      playwright.on('close', () => resolve());
-      playwright.on('error', () => resolve());
+      playwright.on('close', (code) => resolve(code));
+      playwright.on('error', () => resolve(1));
     });
+
+    if (exitCode === 0) {
+      log('Playwright browsers ready', 'green');
+    } else {
+      log(
+        'Playwright installation failed (browser automation may not work)',
+        'yellow'
+      );
+    }
   } catch {
-    // Ignore errors - Playwright install is optional
+    log('Playwright installation skipped', 'yellow');
   }
 
   // Kill any existing processes on required ports


### PR DESCRIPTION
## Problem
The `npm run dev` script appeared to hang at "Checking Playwright browsers..."
with no visible feedback, especially on first run when Chromium needs to be
downloaded (~150-200MB). On slow internet connections, this could take
several minutes with no indication of progress, making users think the
script had frozen.

## Solution
Display Playwright installation output by changing `stdio: 'ignore'` to
`stdio: 'inherit'` in the browser install spawn options.

## Testing
- Run `npm run dev` on a fresh setup (or after clearing Playwright cache)
- Verify download progress is now visible

Solution Result Image
<img width="1330" height="244" alt="image" src="https://github.com/user-attachments/assets/2c730e5a-4c5b-451b-bdea-e6f3f588078c" />

The loading output appears only on a fresh setup.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Formatting and readability improvements across startup and cleanup logic.

* **Chores**
  * Improved output visibility and conditional success/failure messages during browser installation.

* **Bug Fixes**
  * Added pre-start port cleanup and availability wait to prevent startup conflicts.
  * Installation failures now emit warnings instead of being silently ignored.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->