### PR TITLE
fix: Update agent counter to show selected/max concurrency

### DIFF
--- a/apps/ui/src/components/views/board-view/board-header.tsx
+++ b/apps/ui/src/components/views/board-view/board-header.tsx
@@ -1,11 +1,12 @@
+import { Button } from '@/components/ui/button';
+import { HotkeyButton } from '@/components/ui/hotkey-button';
+import { Slider } from '@/components/ui/slider';
+import { Switch } from '@/components/ui/switch';
+import { Label } from '@/components/ui/label';
+import { Plus, Bot } from 'lucide-react';
+import { KeyboardShortcut } from '@/hooks/use-keyboard-shortcuts';
 
-import { Button } from "@/components/ui/button";
-import { HotkeyButton } from "@/components/ui/hotkey-button";
-import { Slider } from "@/components/ui/slider";
-import { Switch } from "@/components/ui/switch";
-import { Label } from "@/components/ui/label";
-import { Plus, Bot } from "lucide-react";
-import { KeyboardShortcut } from "@/hooks/use-keyboard-shortcuts";
+const MAX_CONCURRENCY = 10;
 
 interface BoardHeaderProps {
   projectName: string;
@@ -49,7 +50,7 @@ export function BoardHeader({
               value={[maxConcurrency]}
               onValueChange={(value) => onConcurrencyChange(value[0])}
               min={1}
-              max={10}
+              max={MAX_CONCURRENCY}
               step={1}
               className="w-20"
               data-testid="concurrency-slider"
@@ -58,7 +59,7 @@ export function BoardHeader({
               className="text-sm text-muted-foreground min-w-[5ch] text-center"
               data-testid="concurrency-value"
             >
-              {runningAgentsCount} / {maxConcurrency}
+              {maxConcurrency} / {MAX_CONCURRENCY}
             </span>
           </div>
         )}
@@ -66,10 +67,7 @@ export function BoardHeader({
         {/* Auto Mode Toggle - only show after mount to prevent hydration issues */}
         {isMounted && (
           <div className="flex items-center gap-2 px-3 py-1.5 rounded-lg bg-secondary border border-border">
-            <Label
-              htmlFor="auto-mode-toggle"
-              className="text-sm font-medium cursor-pointer"
-            >
+            <Label htmlFor="auto-mode-toggle" className="text-sm font-medium cursor-pointer">
               Auto Mode
             </Label>
             <Switch


### PR DESCRIPTION
## Summary
Fixed the agent counter display in the top navigation bar to show the selected concurrency limit out of maximum possible instead of running agents count.

## Problem
The slider toggle was showing confusing values like "0 / 1", "0 / 2" where:
- First number: running agents (often 0)
- Second number: selected concurrency limit

## Solution
Changed the display to show "1 / 10", "2 / 10", etc. where:
- First number: selected concurrency limit (what the slider controls)
- Second number: maximum possible concurrency (always 10)

## Changes
- Added `MAX_CONCURRENCY` constant (10) for better maintainability
- Updated display from `{runningAgentsCount} / {maxConcurrency}` to `{maxConcurrency} / {MAX_CONCURRENCY}`
- Updated slider max value to use the constant

## Testing
- Build passes successfully with no TypeScript errors
- Display now correctly shows selected concurrency out of maximum

## Screenshots
_Before:_ Shows "0 / 1" (confusing)
_After:_ Shows "1 / 10" (clear indication of selected vs. max)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added keyboard shortcut support for adding features with enhanced button controls.

* **Bug Fixes**
  * Corrected concurrency ratio display to accurately reflect current limits.

* **Style**
  * Improved Auto Mode toggle layout for better visual presentation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->