### PR TITLE
feat(ui): add backlog pagination and hide feature for suggestions

### DIFF
--- a/apps/ui/src/components/views/board-view.tsx
+++ b/apps/ui/src/components/views/board-view.tsx
@@ -379,6 +379,7 @@ export function BoardView() {
     handleForceStopFeature,
     handleStartNextFeatures,
     handleArchiveAllVerified,
+    handleHideFeature,
   } = useBoardActions({
     currentProject,
     features: hookFeatures,
@@ -744,7 +745,15 @@ export function BoardView() {
   });
 
   // Use column features hook
-  const { getColumnFeatures, completedFeatures } = useBoardColumnFeatures({
+  const {
+    getColumnFeatures,
+    completedFeatures,
+    backlogPagination,
+    showMoreBacklog,
+    showAllBacklog,
+    toggleShowOnlyHidden,
+    resetBacklogPagination,
+  } = useBoardColumnFeatures({
     features: hookFeatures,
     runningAutoTasks,
     searchQuery,
@@ -1021,6 +1030,7 @@ export function BoardView() {
             onImplement={handleStartImplementation}
             onViewPlan={(feature) => setViewPlanFeature(feature)}
             onApprovePlan={handleOpenApprovalDialog}
+            onHide={handleHideFeature}
             featuresWithContext={featuresWithContext}
             runningAutoTasks={runningAutoTasks}
             shortcuts={shortcuts}
@@ -1028,6 +1038,11 @@ export function BoardView() {
             onShowSuggestions={() => setShowSuggestionsDialog(true)}
             suggestionsCount={suggestionsCount}
             onArchiveAllVerified={() => setShowArchiveAllVerifiedDialog(true)}
+            backlogPagination={backlogPagination}
+            onShowMoreBacklog={showMoreBacklog}
+            onShowAllBacklog={showAllBacklog}
+            onToggleShowOnlyHidden={toggleShowOnlyHidden}
+            onResetBacklogPagination={resetBacklogPagination}
           />
         ) : (
           <GraphView

--- a/apps/ui/src/components/views/board-view/components/kanban-card/card-actions.tsx
+++ b/apps/ui/src/components/views/board-view/components/kanban-card/card-actions.tsx
@@ -10,6 +10,7 @@ import {
   Eye,
   Wand2,
   Archive,
+  EyeOff,
 } from 'lucide-react';
 
 interface CardActionsProps {
@@ -28,6 +29,7 @@ interface CardActionsProps {
   onComplete?: () => void;
   onViewPlan?: () => void;
   onApprovePlan?: () => void;
+  onHide?: () => void;
 }
 
 export function CardActions({
@@ -46,6 +48,7 @@ export function CardActions({
   onComplete,
   onViewPlan,
   onApprovePlan,
+  onHide,
 }: CardActionsProps) {
   return (
     <div className="flex flex-wrap gap-1.5 -mx-3 -mb-3 px-3 pb-3">
@@ -298,6 +301,22 @@ export function CardActions({
             <Edit className="w-3 h-3 mr-1" />
             Edit
           </Button>
+          {onHide && (
+            <Button
+              variant="outline"
+              size="sm"
+              className="h-7 text-xs px-2"
+              onClick={(e) => {
+                e.stopPropagation();
+                onHide();
+              }}
+              onPointerDown={(e) => e.stopPropagation()}
+              data-testid={`hide-${feature.id}`}
+              title={feature.hidden ? 'Show' : 'Hide'}
+            >
+              <EyeOff className="w-3 h-3" />
+            </Button>
+          )}
           {feature.planSpec?.content && onViewPlan && (
             <Button
               variant="outline"

--- a/apps/ui/src/components/views/board-view/components/kanban-card/kanban-card.tsx
+++ b/apps/ui/src/components/views/board-view/components/kanban-card/kanban-card.tsx
@@ -25,6 +25,7 @@ interface KanbanCardProps {
   onComplete?: () => void;
   onViewPlan?: () => void;
   onApprovePlan?: () => void;
+  onHide?: () => void;
   hasContext?: boolean;
   isCurrentAutoTask?: boolean;
   shortcutKey?: string;
@@ -51,6 +52,7 @@ export const KanbanCard = memo(function KanbanCard({
   onComplete,
   onViewPlan,
   onApprovePlan,
+  onHide,
   hasContext,
   isCurrentAutoTask,
   shortcutKey,
@@ -177,6 +179,7 @@ export const KanbanCard = memo(function KanbanCard({
           onComplete={onComplete}
           onViewPlan={onViewPlan}
           onApprovePlan={onApprovePlan}
+          onHide={onHide}
         />
       </CardContent>
     </Card>
@@ -185,6 +188,15 @@ export const KanbanCard = memo(function KanbanCard({
   // Wrap with animated border when in progress
   if (isCurrentAutoTask) {
     return <div className="animated-border-wrapper">{cardElement}</div>;
+  }
+
+  // Wrap hidden cards with visual indicator (dimmed + grayscale)
+  if (feature.hidden) {
+    return (
+      <div className="opacity-40 grayscale hover:opacity-70 hover:grayscale-[50%] transition-all duration-200">
+        {cardElement}
+      </div>
+    );
   }
 
   return cardElement;

--- a/apps/ui/src/components/views/board-view/hooks/use-board-actions.ts
+++ b/apps/ui/src/components/views/board-view/hooks/use-board-actions.ts
@@ -859,6 +859,22 @@ export function useBoardActions({
     });
   }, [features, runningAutoTasks, autoMode, updateFeature, persistFeatureUpdate]);
 
+  const handleHideFeature = useCallback(
+    (feature: Feature) => {
+      const newHidden = !feature.hidden;
+      const updates = { hidden: newHidden };
+      updateFeature(feature.id, updates);
+      persistFeatureUpdate(feature.id, updates);
+
+      toast.success(newHidden ? 'Feature hidden' : 'Feature unhidden', {
+        description: newHidden
+          ? `Hidden: ${truncateDescription(feature.description)}`
+          : `Shown: ${truncateDescription(feature.description)}`,
+      });
+    },
+    [updateFeature, persistFeatureUpdate]
+  );
+
   return {
     handleAddFeature,
     handleUpdateFeature,
@@ -879,5 +895,6 @@ export function useBoardActions({
     handleForceStopFeature,
     handleStartNextFeatures,
     handleArchiveAllVerified,
+    handleHideFeature,
   };
 }

--- a/apps/ui/src/components/views/board-view/kanban-board.tsx
+++ b/apps/ui/src/components/views/board-view/kanban-board.tsx
@@ -5,7 +5,16 @@ import { Button } from '@/components/ui/button';
 import { HotkeyButton } from '@/components/ui/hotkey-button';
 import { KanbanColumn, KanbanCard } from './components';
 import { Feature } from '@/store/app-store';
-import { FastForward, Lightbulb, Archive } from 'lucide-react';
+import {
+  FastForward,
+  Lightbulb,
+  Archive,
+  ChevronDown,
+  ChevronsDown,
+  EyeOff,
+  Eye,
+} from 'lucide-react';
+import { cn } from '@/lib/utils';
 import { useKeyboardShortcutsConfig } from '@/hooks/use-keyboard-shortcuts';
 import { useResponsiveKanban } from '@/hooks/use-responsive-kanban';
 import { COLUMNS, ColumnId } from './constants';
@@ -41,6 +50,7 @@ interface KanbanBoardProps {
   onImplement: (feature: Feature) => void;
   onViewPlan: (feature: Feature) => void;
   onApprovePlan: (feature: Feature) => void;
+  onHide: (feature: Feature) => void;
   featuresWithContext: Set<string>;
   runningAutoTasks: string[];
   shortcuts: ReturnType<typeof useKeyboardShortcutsConfig>;
@@ -48,6 +58,18 @@ interface KanbanBoardProps {
   onShowSuggestions: () => void;
   suggestionsCount: number;
   onArchiveAllVerified: () => void;
+  backlogPagination: {
+    totalCount: number;
+    visibleCount: number;
+    hasMore: boolean;
+    remainingCount: number;
+    hiddenCount: number;
+    showOnlyHidden: boolean;
+  };
+  onShowMoreBacklog: () => void;
+  onShowAllBacklog: () => void;
+  onToggleShowOnlyHidden: () => void;
+  onResetBacklogPagination: () => void;
 }
 
 export function KanbanBoard({
@@ -73,6 +95,7 @@ export function KanbanBoard({
   onImplement,
   onViewPlan,
   onApprovePlan,
+  onHide,
   featuresWithContext,
   runningAutoTasks,
   shortcuts,
@@ -80,6 +103,11 @@ export function KanbanBoard({
   onShowSuggestions,
   suggestionsCount,
   onArchiveAllVerified,
+  backlogPagination,
+  onShowMoreBacklog,
+  onShowAllBacklog,
+  onToggleShowOnlyHidden,
+  onResetBacklogPagination,
 }: KanbanBoardProps) {
   // Use responsive column widths based on window size
   // containerStyle handles centering and ensures columns fit without horizontal scroll in Electron
@@ -102,11 +130,15 @@ export function KanbanBoard({
                 id={column.id}
                 title={column.title}
                 colorClass={column.colorClass}
-                count={columnFeatures.length}
+                count={
+                  column.id === 'backlog' ? backlogPagination.totalCount : columnFeatures.length
+                }
                 width={columnWidth}
                 opacity={backgroundSettings.columnOpacity}
                 showBorder={backgroundSettings.columnBorderEnabled}
                 hideScrollbar={backgroundSettings.hideScrollbar}
+                onCompact={column.id === 'backlog' ? onResetBacklogPagination : undefined}
+                visibleCount={column.id === 'backlog' ? backlogPagination.visibleCount : undefined}
                 headerAction={
                   column.id === 'verified' && columnFeatures.length > 0 ? (
                     <Button
@@ -139,6 +171,42 @@ export function KanbanBoard({
                           </span>
                         )}
                       </Button>
+                      {backlogPagination.hiddenCount > 0 && (
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          className={cn(
+                            'h-6 w-6 p-0 relative',
+                            backlogPagination.showOnlyHidden
+                              ? 'text-primary hover:text-primary/80 bg-primary/10 hover:bg-primary/20'
+                              : 'text-muted-foreground hover:text-foreground hover:bg-muted/50'
+                          )}
+                          onClick={onToggleShowOnlyHidden}
+                          title={
+                            backlogPagination.showOnlyHidden
+                              ? 'Show all features'
+                              : `Show ${backlogPagination.hiddenCount} hidden feature${backlogPagination.hiddenCount > 1 ? 's' : ''}`
+                          }
+                          data-testid="show-hidden-button"
+                        >
+                          {backlogPagination.showOnlyHidden ? (
+                            <Eye className="w-3.5 h-3.5" />
+                          ) : (
+                            <EyeOff className="w-3.5 h-3.5" />
+                          )}
+                          <span
+                            className={cn(
+                              'absolute -top-1 -right-1 w-4 h-4 text-[9px] font-mono rounded-full flex items-center justify-center',
+                              backlogPagination.showOnlyHidden
+                                ? 'bg-primary text-primary-foreground'
+                                : 'bg-muted-foreground text-background'
+                            )}
+                            data-testid="hidden-count"
+                          >
+                            {backlogPagination.hiddenCount}
+                          </span>
+                        </Button>
+                      )}
                       {columnFeatures.length > 0 && (
                         <HotkeyButton
                           variant="ghost"
@@ -153,6 +221,32 @@ export function KanbanBoard({
                           Make
                         </HotkeyButton>
                       )}
+                    </div>
+                  ) : undefined
+                }
+                footerAction={
+                  column.id === 'backlog' && backlogPagination.hasMore ? (
+                    <div className="flex gap-1">
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className="flex-1 h-8 text-xs text-muted-foreground hover:text-foreground"
+                        onClick={onShowMoreBacklog}
+                        data-testid="show-more-backlog-button"
+                      >
+                        <ChevronDown className="w-3.5 h-3.5 mr-1" />
+                        +10
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className="flex-1 h-8 text-xs text-muted-foreground hover:text-foreground"
+                        onClick={onShowAllBacklog}
+                        data-testid="show-all-backlog-button"
+                      >
+                        <ChevronsDown className="w-3.5 h-3.5 mr-1" />
+                        All ({backlogPagination.remainingCount})
+                      </Button>
                     </div>
                   ) : undefined
                 }
@@ -184,6 +278,7 @@ export function KanbanBoard({
                         onImplement={() => onImplement(feature)}
                         onViewPlan={() => onViewPlan(feature)}
                         onApprovePlan={() => onApprovePlan(feature)}
+                        onHide={() => onHide(feature)}
                         hasContext={featuresWithContext.has(feature.id)}
                         isCurrentAutoTask={runningAutoTasks.includes(feature.id)}
                         shortcutKey={shortcutKey}

--- a/libs/types/src/feature.ts
+++ b/libs/types/src/feature.ts
@@ -30,6 +30,7 @@ export interface Feature {
   passes?: boolean;
   priority?: number;
   status?: string;
+  hidden?: boolean; // Hidden features appear at the bottom of backlog
   dependencies?: string[];
   spec?: string;
   model?: string;


### PR DESCRIPTION
## Summary

- **Hide feature**: Adds a hide button to backlog cards, allowing users to hide suggestions they don't want to see right now. Hidden features appear dimmed and can be toggled back.
- **Filter mode**: Eye icon in the backlog header shows count of hidden features. Clicking it filters to show *only* hidden features for easy management.
- **Pagination**: Backlog now shows 10 items at a time with "+10" and "All" buttons at the bottom.
- **Compact bar**: A sticky "Compact" bar appears when scrolling down in the backlog, allowing quick return to top and reset to initial 10 items.

### Why this matters
When using AI to generate suggestions, backlogs can grow to 100+ items. This makes:
- Scrolling slow and the list overwhelming
- It hard to manage unwanted suggestions without deleting them permanently

### Demo
Hidden cards are visually dimmed (40% opacity + grayscale) to indicate their state. The filter toggle in the header makes it easy to review and unhide features.

## Test plan

- [ ] Verify hide button appears in backlog card actions menu
- [ ] Verify clicking hide dims the card and shows toast
- [ ] Verify hidden count badge appears in header when features are hidden
- [ ] Verify clicking eye icon shows only hidden features
- [ ] Verify pagination shows 10 items initially
- [ ] Verify "+10" button loads 10 more items
- [ ] Verify "All" button shows all items
- [ ] Verify compact bar appears when scrolling down
- [ ] Verify clicking compact bar scrolls to top and resets to 10 items
- [ ] Verify hidden state persists after page reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Hide/unhide individual features on the board; hidden features display with reduced opacity for easy identification
  * Backlog pagination with "Show More" and "Show All" controls to manage large backlogs more effectively
  * Filter toggle to view only hidden backlog items
  * Compact navigation bar appears when scrolling the backlog for quick access to the top

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->