### PR TITLE
feat: Add a stop button to halt agent execution when processing.

### DIFF
--- a/apps/ui/src/components/views/agent-view.tsx
+++ b/apps/ui/src/components/views/agent-view.tsx
@@ -17,6 +17,7 @@ import {
   ImageIcon,
   ChevronDown,
   FileText,
+  Square,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useElectronAgent } from '@/hooks/use-electron-agent';
@@ -83,6 +84,7 @@ export function AgentView() {
     isConnected,
     sendMessage,
     clearHistory,
+    stopExecution,
     error: agentError,
   } = useElectronAgent({
     sessionId: currentSessionId || '',
@@ -914,21 +916,33 @@ export function AgentView() {
                 <Paperclip className="w-4 h-4" />
               </Button>
 
-              {/* Send Button */}
-              <Button
-                onClick={handleSend}
-                disabled={
-                  (!input.trim() &&
-                    selectedImages.length === 0 &&
-                    selectedTextFiles.length === 0) ||
-                  isProcessing ||
-                  !isConnected
-                }
-                className="h-11 px-4 rounded-xl"
-                data-testid="send-message"
-              >
-                <Send className="w-4 h-4" />
-              </Button>
+              {/* Send / Stop Button */}
+              {isProcessing ? (
+                <Button
+                  onClick={stopExecution}
+                  disabled={!isConnected}
+                  className="h-11 px-4 rounded-xl"
+                  variant="destructive"
+                  data-testid="stop-agent"
+                  title="Stop generation"
+                >
+                  <Square className="w-4 h-4 fill-current" />
+                </Button>
+              ) : (
+                <Button
+                  onClick={handleSend}
+                  disabled={
+                    (!input.trim() &&
+                      selectedImages.length === 0 &&
+                      selectedTextFiles.length === 0) ||
+                    !isConnected
+                  }
+                  className="h-11 px-4 rounded-xl"
+                  data-testid="send-message"
+                >
+                  <Send className="w-4 h-4" />
+                </Button>
+              )}
             </div>
 
             {/* Keyboard hint */}


### PR DESCRIPTION
## Summary: Closes #230 
This PR adds a "Stop" button to the Agent Runner UI, allowing users to interrupt and cancel an active agent execution. This addresses the issue where users were unable to halt the agent once a request was sent.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Detailed Description
**UI Changes in `apps/ui/src/components/views/agent-view.tsx`:**

*   Imported the `Square` icon from `lucide-react` to serve as the stop icon.
*   Integrated the `stopExecution` function from the `useElectronAgent` hook.
*   Modified the main action button logic:
    *   When `isProcessing` is **true**, the button now renders as a "Stop" button (destructive variant, square icon).
    *   When `isProcessing` is **false**, it retains the original "Send" functionality.
*   Added a `disabled={!isConnected}` check to the Stop button to ensure the agent is connected before attempting to stop.

**Logic:**
The `stopExecution` function effectively aborts the underlying `AbortController` in the backend service, stopping the stream and generation process immediately.

## Testing
1.  Navigate to the "Agent Runner" tab.
2.  Send a long prompt (e.g., "Count to 100 with a story for each number").
3.  Observe the "Send" button changing to a "Stop" button.
4.  Click "Stop".
5.  Verify that the agent stops typing and the UI returns to the "ready" state.

<img width="3197" height="1835" alt="button-added" src="https://github.com/user-attachments/assets/bb1f6e3f-0ab6-48f6-96ae-0f27ef91973a" />
