### PR TITLE
fix: Open in Browser button not working on Windows

### DIFF
--- a/apps/ui/src/components/views/board-view/worktree-panel/hooks/use-dev-servers.ts
+++ b/apps/ui/src/components/views/board-view/worktree-panel/hooks/use-dev-servers.ts
@@ -114,13 +114,12 @@ export function useDevServers({ projectPath }: UseDevServersOptions) {
 
   const handleOpenDevServerUrl = useCallback(
     (worktree: WorktreeInfo) => {
-      const targetPath = worktree.isMain ? projectPath : worktree.path;
-      const serverInfo = runningDevServers.get(targetPath);
+      const serverInfo = runningDevServers.get(getWorktreeKey(worktree));
       if (serverInfo) {
         window.open(serverInfo.url, '_blank');
       }
     },
-    [projectPath, runningDevServers]
+    [runningDevServers, getWorktreeKey]
   );
 
   const isDevServerRunning = useCallback(


### PR DESCRIPTION
The handleOpenDevServerUrl function was looking up the dev server info using an un-normalized path, but the Map stores entries with normalized paths (forward slashes).

On Windows, paths come in as C:\Projects\foo but stored keys use C:/Projects/foo (normalized). The lookup used the raw path, so it never matched.

Fix: Use getWorktreeKey() helper which normalizes the path, consistent with how isDevServerRunning() and getDevServerInfo() already work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dev server resolution to correctly identify and open the appropriate server instance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->