### PR TITLE
fix: use CSS variables for universal scrollbar styling across all themes

### DIFF
--- a/apps/ui/src/styles/global.css
+++ b/apps/ui/src/styles/global.css
@@ -389,78 +389,23 @@
   }
 }
 
-/* Custom scrollbar for dark themes */
-:is(
-    .dark,
-    .retro,
-    .dracula,
-    .nord,
-    .monokai,
-    .tokyonight,
-    .solarized,
-    .gruvbox,
-    .catppuccin,
-    .onedark,
-    .synthwave,
-    .red,
-    .sunset,
-    .gray
-  )
-  ::-webkit-scrollbar {
+/* Universal scrollbar styling using theme CSS variables */
+::-webkit-scrollbar {
   width: 8px;
   height: 8px;
 }
 
-:is(
-    .dark,
-    .retro,
-    .dracula,
-    .nord,
-    .monokai,
-    .tokyonight,
-    .solarized,
-    .gruvbox,
-    .catppuccin,
-    .onedark,
-    .synthwave,
-    .red,
-    .sunset,
-    .gray
-  )
-  ::-webkit-scrollbar-track {
+::-webkit-scrollbar-track {
   background: var(--muted);
 }
 
-:is(.dark, .retro) ::-webkit-scrollbar-thumb {
-  background: oklch(0.3 0 0);
+::-webkit-scrollbar-thumb {
+  background: var(--muted-foreground);
   border-radius: 4px;
 }
 
-:is(.dark, .retro) ::-webkit-scrollbar-thumb:hover {
-  background: oklch(0.4 0 0);
-}
-
-/* Retro Scrollbar override */
-.retro ::-webkit-scrollbar-thumb {
-  background: var(--primary);
-  border-radius: 0;
-}
-.retro ::-webkit-scrollbar-track {
-  background: var(--background);
-}
-
-/* Red theme scrollbar */
-.red ::-webkit-scrollbar-thumb {
-  background: oklch(0.35 0.15 25);
-  border-radius: 4px;
-}
-
-.red ::-webkit-scrollbar-thumb:hover {
-  background: oklch(0.45 0.18 25);
-}
-
-.red ::-webkit-scrollbar-track {
-  background: oklch(0.15 0.05 25);
+::-webkit-scrollbar-thumb:hover {
+  background: var(--foreground);
 }
 
 /* Always visible scrollbar for file diffs and code blocks */

--- a/apps/ui/src/styles/themes/red.css
+++ b/apps/ui/src/styles/themes/red.css
@@ -67,3 +67,17 @@
   --running-indicator: oklch(0.55 0.25 25);
   --running-indicator-text: oklch(0.6 0.23 25);
 }
+
+/* Red theme scrollbar */
+.red ::-webkit-scrollbar-thumb {
+  background: oklch(0.35 0.15 25);
+  border-radius: 4px;
+}
+
+.red ::-webkit-scrollbar-thumb:hover {
+  background: oklch(0.45 0.18 25);
+}
+
+.red ::-webkit-scrollbar-track {
+  background: oklch(0.15 0.05 25);
+}

--- a/apps/ui/src/styles/themes/retro.css
+++ b/apps/ui/src/styles/themes/retro.css
@@ -86,6 +86,16 @@
 
 /* Theme-specific overrides */
 
+/* Retro Scrollbar - sharp edges with neon green */
+.retro ::-webkit-scrollbar-thumb {
+  background: var(--primary);
+  border-radius: 0;
+}
+
+.retro ::-webkit-scrollbar-track {
+  background: var(--background);
+}
+
 .retro .scrollbar-visible::-webkit-scrollbar-thumb {
   background: var(--primary);
   border-radius: 0;


### PR DESCRIPTION
## Description

- Replaced manual theme lists with universal CSS variable-based scrollbar styling using `--muted-foreground` and `--muted`
- Moved theme-specific scrollbar overrides from `global.css` to their respective theme files (`retro.css`, `red.css`)
- Fixes invisible scrollbars in themes that were missing thumb color definitions (dracula, nord, monokai, etc.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Refined scrollbar styling to ensure consistent appearance across all themes, with improved visual integration for red and retro theme variants.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->