### PR TITLE
fix: add retry mechanisms to context test helpers for flaky test stability

### DIFF
--- a/apps/ui/tests/context/context-file-management.spec.ts
+++ b/apps/ui/tests/context/context-file-management.spec.ts
@@ -50,7 +50,8 @@ test.describe('Context File Management', () => {
       { timeout: 5000 }
     );
 
-    await waitForContextFile(page, 'test-context.md', 10000);
+    await waitForNetworkIdle(page);
+    await waitForContextFile(page, 'test-context.md');
 
     const fileButton = await getByTestId(page, 'context-file-test-context.md');
     await expect(fileButton).toBeVisible();

--- a/apps/ui/tests/context/delete-context-file.spec.ts
+++ b/apps/ui/tests/context/delete-context-file.spec.ts
@@ -53,7 +53,7 @@ test.describe('Delete Context File', () => {
     );
 
     // Wait for the file to appear in the list
-    await waitForContextFile(page, fileName, 10000);
+    await waitForContextFile(page, fileName);
 
     // Select the file
     await selectContextFile(page, fileName);


### PR DESCRIPTION
## Summary
- Update `waitForContextFile`, `selectContextFile`, and `waitForFileContentToLoad` helpers to use Playwright's `expect().toPass()` with retry intervals `[500, 1000, 2000]`
- Handle race conditions between API calls completing and UI re-rendering
- Add `waitForNetworkIdle()` after dialog closes in context-file-management test

Verified stable with 10x repeated test runs (120/120 passed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test reliability by replacing fixed timeout waits with network-idle detection and retry-based synchronization.
  * Increased default test utility timeouts from 10s to 15s to reduce flakes and better accommodate asynchronous UI loading.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->