### PR TITLE
fix: include libs directory in Electron build extraResources

### DIFF
--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -142,6 +142,10 @@
         "to": "server/node_modules"
       },
       {
+        "from": "server-bundle/libs",
+        "to": "server/libs"
+      },
+      {
         "from": "server-bundle/package.json",
         "to": "server/package.json"
       },


### PR DESCRIPTION
## Summary

- Fix "Server failed to start" error in packaged Electron app caused by broken symlinks

## Problem

The `@automaker/*` packages in `server-bundle/node_modules` are symlinks pointing to `../../libs/...`. The `libs` directory was being prepared by `prepare-server.mjs` but wasn't included in the `extraResources` configuration, so the symlinks were broken in the packaged app.

## Solution

Add the `server-bundle/libs` directory to `extraResources` in `apps/ui/package.json` so the symlink targets are available in the packaged app.

## Testing

- Built with `npm run build:electron:mac`
- Verified `libs/` directory is present in packaged app at `Contents/Resources/server/libs/`
- App launches successfully without "Server failed to start" error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Packaging updated to include additional server runtime resources in distributed builds.

* **Bug Fixes**
  * Sandbox mode now automatically disables for projects stored in cloud-sync locations (avoids sandbox-related failures there).

* **Tests**
  * Added unit tests covering cloud-sync path detection and sandbox auto-disable behavior across scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->