### PR TITLE
fix: auto-disable sandbox mode for cloud storage paths

### DIFF
--- a/apps/server/src/lib/sdk-options.ts
+++ b/apps/server/src/lib/sdk-options.ts
@@ -147,15 +147,15 @@ export function checkSandboxCompatibility(
   cwd: string,
   enableSandboxMode?: boolean
 ): SandboxCheckResult {
-  // User has disabled sandbox mode
-  if (!enableSandboxMode) {
+  // User has explicitly disabled sandbox mode
+  if (enableSandboxMode === false) {
     return {
       enabled: false,
       disabledReason: 'user_setting',
     };
   }
 
-  // Check for cloud storage incompatibility
+  // Check for cloud storage incompatibility (applies when enabled or undefined)
   if (isCloudStoragePath(cwd)) {
     return {
       enabled: false,
@@ -164,7 +164,7 @@ export function checkSandboxCompatibility(
     };
   }
 
-  // Sandbox is compatible and enabled
+  // Sandbox is compatible and enabled (true or undefined defaults to enabled)
   return {
     enabled: true,
   };

--- a/apps/server/tests/unit/lib/sdk-options.test.ts
+++ b/apps/server/tests/unit/lib/sdk-options.test.ts
@@ -140,11 +140,21 @@ describe('sdk-options.ts', () => {
       expect(result.disabledReason).toBeUndefined();
     });
 
-    it('should return enabled=false when enableSandboxMode is undefined', async () => {
+    it('should return enabled=true when enableSandboxMode is undefined for local paths', async () => {
       const { checkSandboxCompatibility } = await import('@/lib/sdk-options.js');
       const result = checkSandboxCompatibility('/Users/test/project', undefined);
+      expect(result.enabled).toBe(true);
+      expect(result.disabledReason).toBeUndefined();
+    });
+
+    it('should return enabled=false for cloud storage paths when enableSandboxMode is undefined', async () => {
+      const { checkSandboxCompatibility } = await import('@/lib/sdk-options.js');
+      const result = checkSandboxCompatibility(
+        '/Users/test/Library/CloudStorage/Dropbox-Personal/project',
+        undefined
+      );
       expect(result.enabled).toBe(false);
-      expect(result.disabledReason).toBe('user_setting');
+      expect(result.disabledReason).toBe('cloud_storage');
     });
   });
 
@@ -360,14 +370,17 @@ describe('sdk-options.ts', () => {
       expect(options.sandbox).toBeUndefined();
     });
 
-    it('should not set sandbox when enableSandboxMode is not provided', async () => {
+    it('should enable sandbox by default when enableSandboxMode is not provided', async () => {
       const { createChatOptions } = await import('@/lib/sdk-options.js');
 
       const options = createChatOptions({
         cwd: '/test/path',
       });
 
-      expect(options.sandbox).toBeUndefined();
+      expect(options.sandbox).toEqual({
+        enabled: true,
+        autoAllowBashIfSandboxed: true,
+      });
     });
 
     it('should auto-disable sandbox for cloud storage paths', async () => {
@@ -432,14 +445,17 @@ describe('sdk-options.ts', () => {
       expect(options.sandbox).toBeUndefined();
     });
 
-    it('should not set sandbox when enableSandboxMode is not provided', async () => {
+    it('should enable sandbox by default when enableSandboxMode is not provided', async () => {
       const { createAutoModeOptions } = await import('@/lib/sdk-options.js');
 
       const options = createAutoModeOptions({
         cwd: '/test/path',
       });
 
-      expect(options.sandbox).toBeUndefined();
+      expect(options.sandbox).toEqual({
+        enabled: true,
+        autoAllowBashIfSandboxed: true,
+      });
     });
 
     it('should auto-disable sandbox for cloud storage paths', async () => {
@@ -448,6 +464,16 @@ describe('sdk-options.ts', () => {
       const options = createAutoModeOptions({
         cwd: '/Users/test/Library/CloudStorage/Dropbox-Personal/project',
         enableSandboxMode: true,
+      });
+
+      expect(options.sandbox).toBeUndefined();
+    });
+
+    it('should auto-disable sandbox for cloud storage paths even when enableSandboxMode is not provided', async () => {
+      const { createAutoModeOptions } = await import('@/lib/sdk-options.js');
+
+      const options = createAutoModeOptions({
+        cwd: '/Users/test/Library/CloudStorage/Dropbox-Personal/project',
       });
 
       expect(options.sandbox).toBeUndefined();


### PR DESCRIPTION
## Summary

- Auto-disable sandbox mode when project is in a cloud storage location (Dropbox, Google Drive, iCloud, OneDrive)

## Problem

The Claude CLI sandbox feature is incompatible with cloud storage virtual filesystems. When sandbox mode is enabled for projects in these locations, the Claude process exits with code 1, causing "Server failed to start" or agent execution failures.

## Solution

Added automatic detection and graceful degradation:

- `isCloudStoragePath(cwd)` - Detects cloud storage locations
- `checkSandboxCompatibility(cwd, enableSandboxMode)` - Returns whether sandbox should be enabled
- Updated `createChatOptions()` and `createAutoModeOptions()` to auto-disable sandbox for cloud storage paths

When sandbox is auto-disabled, a warning is logged:
```
[SdkOptions] Sandbox mode auto-disabled: Project is in a cloud storage location...
```

## Testing

- Added 15 new tests for cloud storage detection and sandbox behavior
- All 765 server tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sandbox mode now auto-disables when a project is detected in cloud storage (Dropbox, Google Drive, OneDrive, or macOS iCloud/Home-anchored folders) while still respecting explicit user settings; option flows now reflect this behavior.

* **Tests**
  * Added unit tests covering cloud-storage detection and sandbox auto-disable across relevant option creation paths.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->