### PR TITLE
docs: update security vulnerability reporting to Discord

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -670,7 +670,7 @@ immediate preview.
 
 **Important:** If you discover a security vulnerability, please do NOT open a public issue. Instead:
 
-1. Write to [@webdevcody](https://discord.gg/jjem7aEDKU) on Discord
+1. Join our [Discord server](https://discord.gg/jjem7aEDKU) and send a direct message to the user `@webdevcody`
 2. Include detailed steps to reproduce
 3. Allow time for us to address the issue before public disclosure
 


### PR DESCRIPTION
## Summary

Replace non-existent email contact method with Discord contact for security vulnerability reporting in the Contributing Guide.

- Updated security issues section to direct reporters to @webdevcody on Discord
- Maintains consistency with existing community support channels
- Removes broken contact method

## Changes

- Modified `CONTRIBUTING.md` line 673 to use Discord contact instead of email

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated contributor guidance for reporting security vulnerabilities: switched from email to a Discord-based reporting process, and relocated contact instructions accordingly. This change clarifies how to submit security concerns and where to find the updated reporting steps in the project documentation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->