### PR TITLE
fix: resolve auth race condition causing 401 errors on Electron startup

### DIFF
--- a/apps/ui/src/hooks/use-settings-migration.ts
+++ b/apps/ui/src/hooks/use-settings-migration.ts
@@ -18,7 +18,7 @@
  */
 
 import { useEffect, useState, useRef } from 'react';
-import { getHttpApiClient } from '@/lib/http-api-client';
+import { getHttpApiClient, waitForApiKeyInit } from '@/lib/http-api-client';
 import { isElectron } from '@/lib/electron';
 import { getItem, removeItem } from '@/lib/storage';
 import { useAppStore } from '@/store/app-store';
@@ -99,6 +99,10 @@ export function useSettingsMigration(): MigrationState {
       }
 
       try {
+        // Wait for API key to be initialized before making any API calls
+        // This prevents 401 errors on startup in Electron mode
+        await waitForApiKeyInit();
+
         const api = getHttpApiClient();
 
         // Check if server has settings files


### PR DESCRIPTION
API requests were being made before initApiKey() completed, causing 401 Unauthorized errors on app startup in Electron mode.

Changes:
- Add waitForApiKeyInit() to track and await API key initialization
- Make HTTP methods (get/post/put/delete) wait for auth before requests
- Defer WebSocket connection until API key is ready
- Add explicit auth wait in useSettingsMigration hook

Fixes race condition introduced in PR #321

---
# Fix Report: Auth Race Condition (401 Errors on Startup)

## Summary

Fixed the race condition where API requests were made before `initApiKey()` completed, causing 401 errors on Electron app startup.

## Root Cause

In PR #321 (`protect-api-with-api-key`), the authentication system was hardened to require API keys for all requests. However, `initApiKey()` was called asynchronously in a `useEffect` hook, while other hooks (`useSettingsMigration`, `useRunningAgents`) immediately created `HttpApiClient` instances and made API requests before the API key was fetched from Electron's main process.

**Timeline of the bug:**
1. App starts, React renders components
2. `useSettingsMigration` and other hooks call `getHttpApiClient()` 
3. `HttpApiClient` constructor calls `connectWebSocket()` which needs auth
4. API requests fire with `getApiKey()` returning `null`
5. Server returns 401 Unauthorized
6. *Later*, `initApiKey()` in `__root.tsx` useEffect finally completes
7. `[HTTP Client] Using API key from Electron` appears in logs - too late!

## Changes Made

### 1. `apps/ui/src/lib/http-api-client.ts`

**Added `apiKeyInitPromise` to track initialization:**
```typescript
let apiKeyInitPromise: Promise<void> | null = null;
```

**Added `waitForApiKeyInit()` helper function:**
```typescript
export const waitForApiKeyInit = (): Promise<void> => {
  if (apiKeyInitialized) return Promise.resolve();
  if (apiKeyInitPromise) return apiKeyInitPromise;
  return initApiKey();
};
```

**Modified `initApiKey()` to return a trackable promise:**
- Stores the initialization promise so concurrent calls wait for the same initialization
- Prevents duplicate initialization attempts

**Modified `HttpApiClient` constructor to wait for auth:**
```typescript
constructor() {
  this.serverUrl = getServerUrl();
  // Wait for API key initialization before connecting WebSocket
  waitForApiKeyInit().then(() => {
    this.connectWebSocket();
  });
}
```

**Modified HTTP methods (`get`, `post`, `put`, `httpDelete`) to wait for auth:**
```typescript
private async get<T>(endpoint: string): Promise<T> {
  // Ensure API key is initialized before making request
  await waitForApiKeyInit();
  // ... rest of method
}
```

### 2. `apps/ui/src/hooks/use-settings-migration.ts`

**Added wait for auth before API calls:**
```typescript
import { getHttpApiClient, waitForApiKeyInit } from '@/lib/http-api-client';

// In checkAndMigrate():
await waitForApiKeyInit();
const api = getHttpApiClient();
```

## Testing

After the fix:
- `[HTTP Client] Using API key from Electron` appears BEFORE any API requests
- No more 401 errors on startup
- WebSocket connects successfully
- Settings migration works correctly

## Files Changed

1. `apps/ui/src/lib/http-api-client.ts` - Core fix for auth initialization
2. `apps/ui/src/hooks/use-settings-migration.ts` - Added explicit wait for auth

## Notes

- The fix uses a promise-based approach that allows all API methods to wait for auth
- This is backwards-compatible - web mode (cookie-based auth) still works
- The `waitForApiKeyInit()` function returns immediately if already initialized, so there's no performance penalty after first load
- Consider adding similar waits to any other hooks that make early API calls

## Related

- Original PR: #321 (`protect-api-with-api-key`)
- Commits that introduced regression: `d68de99`, `469ee5f`, `d66259b`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed 401 authentication errors during startup by ensuring API key initialization completes before HTTP requests and real-time connections.
  * Improved startup behavior to avoid repeated initialization attempts and to fall back to cookie-based authentication with a warning when needed, while still attempting real-time connections.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->