### PR TITLE
fix: add openssh-client to Dockerfile to fix `ssh command not found`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,7 @@ RUN npm run build:packages && npm run build --workspace=apps/server
 # =============================================================================
 FROM node:22-alpine AS server
 
-# Install git, curl, bash (for terminal), su-exec (for user switching), and GitHub CLI (pinned version, multi-arch)
+# Install git, curl, bash (for terminal), su-exec (for user switching), openssh-client (git operations via ssh), and GitHub CLI (pinned version, multi-arch)
 RUN apk add --no-cache git curl bash su-exec openssh-client && \
     GH_VERSION="2.63.2" && \
     ARCH=$(uname -m) && \


### PR DESCRIPTION
I had my git repo set use origin ` git@github.com:user/whatever.git` (so not the https://... format)

Automaker git pull/push would fail and logs would point to `ssh command not found` ( so git was attempting to pull git repo via `ssh` and public key, and fail wit really unhelpful error message. So now with `ssh` present the error is more clear `Permission denied (publickey). Please make sure you have the correct access rights) `)

`ssh` is part of `openssh-client`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added SSH client support to the production environment.
  * No functional behavior changes expected; this provides SSH tooling within the production image.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->