### PR TITLE
refactor: replace git command for branch retrieval

### DIFF
--- a/apps/server/src/routes/worktree/routes/checkout-branch.ts
+++ b/apps/server/src/routes/worktree/routes/checkout-branch.ts
@@ -47,7 +47,7 @@ export function createCheckoutBranchHandler() {
       }
 
       // Get current branch for reference
-      const { stdout: currentBranchOutput } = await execAsync('git rev-parse --abbrev-ref HEAD', {
+      const { stdout: currentBranchOutput } = await execAsync('git symbolic-ref --short HEAD', {
         cwd: worktreePath,
       });
       const currentBranch = currentBranchOutput.trim();

--- a/apps/server/src/routes/worktree/routes/commit.ts
+++ b/apps/server/src/routes/worktree/routes/commit.ts
@@ -59,7 +59,7 @@ export function createCommitHandler() {
       const commitHash = hashOutput.trim().substring(0, 8);
 
       // Get branch name
-      const { stdout: branchOutput } = await execAsync('git rev-parse --abbrev-ref HEAD', {
+      const { stdout: branchOutput } = await execAsync('git symbolic-ref --short HEAD', {
         cwd: worktreePath,
       });
       const branchName = branchOutput.trim();

--- a/apps/server/src/routes/worktree/routes/create-pr.ts
+++ b/apps/server/src/routes/worktree/routes/create-pr.ts
@@ -43,7 +43,7 @@ export function createCreatePRHandler() {
       const effectiveProjectPath = projectPath || worktreePath;
 
       // Get current branch name
-      const { stdout: branchOutput } = await execAsync('git rev-parse --abbrev-ref HEAD', {
+      const { stdout: branchOutput } = await execAsync('git symbolic-ref --short HEAD', {
         cwd: worktreePath,
         env: execEnv,
       });

--- a/apps/server/src/routes/worktree/routes/delete.ts
+++ b/apps/server/src/routes/worktree/routes/delete.ts
@@ -38,7 +38,7 @@ export function createDeleteHandler() {
       // Get branch name before removing worktree
       let branchName: string | null = null;
       try {
-        const { stdout } = await execAsync('git rev-parse --abbrev-ref HEAD', {
+        const { stdout } = await execAsync('git symbolic-ref --short HEAD', {
           cwd: worktreePath,
         });
         branchName = stdout.trim();

--- a/apps/server/src/routes/worktree/routes/info.ts
+++ b/apps/server/src/routes/worktree/routes/info.ts
@@ -31,7 +31,7 @@ export function createInfoHandler() {
       const worktreePath = path.join(projectPath, '.worktrees', featureId);
       try {
         await secureFs.access(worktreePath);
-        const { stdout } = await execAsync('git rev-parse --abbrev-ref HEAD', {
+        const { stdout } = await execAsync('git symbolic-ref --short HEAD', {
           cwd: worktreePath,
         });
         res.json({

--- a/apps/server/src/routes/worktree/routes/list-branches.ts
+++ b/apps/server/src/routes/worktree/routes/list-branches.ts
@@ -34,7 +34,7 @@ export function createListBranchesHandler() {
       }
 
       // Get current branch
-      const { stdout: currentBranchOutput } = await execAsync('git rev-parse --abbrev-ref HEAD', {
+      const { stdout: currentBranchOutput } = await execAsync('git symbolic-ref --short HEAD', {
         cwd: worktreePath,
       });
       const currentBranch = currentBranchOutput.trim();

--- a/apps/server/src/routes/worktree/routes/merge.ts
+++ b/apps/server/src/routes/worktree/routes/merge.ts
@@ -35,7 +35,7 @@ export function createMergeHandler() {
       const worktreePath = path.join(projectPath, '.worktrees', featureId);
 
       // Get current branch
-      const { stdout: currentBranch } = await execAsync('git rev-parse --abbrev-ref HEAD', {
+      const { stdout: currentBranch } = await execAsync('git symbolic-ref --short HEAD', {
         cwd: projectPath,
       });
 

--- a/apps/server/src/routes/worktree/routes/pull.ts
+++ b/apps/server/src/routes/worktree/routes/pull.ts
@@ -28,7 +28,7 @@ export function createPullHandler() {
       }
 
       // Get current branch name
-      const { stdout: branchOutput } = await execAsync('git rev-parse --abbrev-ref HEAD', {
+      const { stdout: branchOutput } = await execAsync('git symbolic-ref --short HEAD', {
         cwd: worktreePath,
       });
       const branchName = branchOutput.trim();

--- a/apps/server/src/routes/worktree/routes/push.ts
+++ b/apps/server/src/routes/worktree/routes/push.ts
@@ -29,7 +29,7 @@ export function createPushHandler() {
       }
 
       // Get branch name
-      const { stdout: branchOutput } = await execAsync('git rev-parse --abbrev-ref HEAD', {
+      const { stdout: branchOutput } = await execAsync('git symbolic-ref --short HEAD', {
         cwd: worktreePath,
       });
       const branchName = branchOutput.trim();

--- a/apps/server/src/routes/worktree/routes/switch-branch.ts
+++ b/apps/server/src/routes/worktree/routes/switch-branch.ts
@@ -87,7 +87,7 @@ export function createSwitchBranchHandler() {
       }
 
       // Get current branch
-      const { stdout: currentBranchOutput } = await execAsync('git rev-parse --abbrev-ref HEAD', {
+      const { stdout: currentBranchOutput } = await execAsync('git symbolic-ref --short HEAD', {
         cwd: worktreePath,
       });
       const previousBranch = currentBranchOutput.trim();


### PR DESCRIPTION
- Updated multiple route handlers to use 'git symbolic-ref --short HEAD' instead of 'git rev-parse --abbrev-ref HEAD' for retrieving the current branch name, improving consistency and clarity in branch management across the application.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated branch detection method across worktree operations (checkout, commit, PR creation, delete, info, list branches, merge, pull, push, and switch). This improves accuracy of branch identification in standard Git workflows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->