### PR TITLE
fix(electron): suppress verbose startup logs in Electron mode

### DIFF
--- a/apps/server/src/routes/app-spec/common.ts
+++ b/apps/server/src/routes/app-spec/common.ts
@@ -35,11 +35,7 @@ export function logAuthStatus(context: string): void {
   const hasApiKey = !!process.env.ANTHROPIC_API_KEY;
 
   logger.info(`${context} - Auth Status:`);
-  logger.info(
-    `  ANTHROPIC_API_KEY: ${
-      hasApiKey ? 'SET (' + process.env.ANTHROPIC_API_KEY?.substring(0, 20) + '...)' : 'NOT SET'
-    }`
-  );
+  logger.info(`  ANTHROPIC_API_KEY: ${hasApiKey ? 'SET' : 'NOT SET'}`);
 
   if (!hasApiKey) {
     logger.warn('⚠️  WARNING: No authentication configured! SDK will fail.');

--- a/apps/ui/src/main.ts
+++ b/apps/ui/src/main.ts
@@ -47,7 +47,7 @@ const VITE_DEV_SERVER_URL = process.env.VITE_DEV_SERVER_URL;
 if (isDev) {
   try {
     // eslint-disable-next-line @typescript-eslint/no-require-imports
-    require('dotenv').config({ path: path.join(__dirname, '../.env') });
+    require('dotenv').config({ path: path.join(__dirname, '../.env'), quiet: true });
   } catch (error) {
     logger.warn('dotenv not available:', (error as Error).message);
   }
@@ -485,6 +485,10 @@ async function startServer(): Promise<void> {
     NODE_PATH: serverNodeModules,
     // Pass API key to server for CSRF protection
     AUTOMAKER_API_KEY: apiKey!,
+    // Indicate Electron execution context to server
+    AUTOMAKER_ELECTRON: 'true',
+    // Suppress API key banner in Electron (auth handled automatically)
+    AUTOMAKER_HIDE_API_KEY: 'true',
     // Only set ALLOWED_ROOT_DIRECTORY if explicitly provided in environment
     // If not set, server will allow access to all paths
     ...(process.env.ALLOWED_ROOT_DIRECTORY && {


### PR DESCRIPTION
## Summary
- Add `quiet: true` to dotenv config in Electron main process
- Set `AUTOMAKER_ELECTRON` and `AUTOMAKER_HIDE_API_KEY` env vars for server
- Suppress API key banner when spawned by Electron (auth is automatic)
- Remove partial Anthropic key logging for security

## Test plan
- [x] Electron mode: No dotenv injection message, no API key banner box
- [x] Web mode: API key banner still displays correctly
- [x] Codex verification passed

## Files changed
- `apps/ui/src/main.ts` (2 changes)
- `apps/server/src/routes/app-spec/common.ts` (1 change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Updated API key logging to display only authentication status (SET or NOT SET) instead of exposing actual key values.
* Implemented automatic authentication handling when running in Electron application environments.
* Reduced startup process log verbosity for improved initialization clarity and cleaner console output.
* Added environment-based controls for authentication banner visibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->