### PR TITLE
fix: add API key header to verifySession for Electron auth

### DIFF
--- a/apps/ui/src/lib/http-api-client.ts
+++ b/apps/ui/src/lib/http-api-client.ts
@@ -374,7 +374,13 @@ export const verifySession = async (): Promise<boolean> => {
     'Content-Type': 'application/json',
   };
 
-  // Add session token header if available
+  // Electron mode: use API key header
+  const apiKey = getApiKey();
+  if (apiKey) {
+    headers['X-API-Key'] = apiKey;
+  }
+
+  // Add session token header if available (web mode)
   const sessionToken = getSessionToken();
   if (sessionToken) {
     headers['X-Session-Token'] = sessionToken;


### PR DESCRIPTION
## Summary
- Fix Electron mode showing "You've been logged out" screen on startup
- Add missing `X-API-Key` header to `verifySession()` function
- The function only included session token (web mode) but not API key (Electron mode)

## Root Cause
The `verifySession()` function in `http-api-client.ts` was not including the `X-API-Key` header when checking authentication status. In Electron mode, authentication uses API key headers, not session cookies. This caused `/api/settings/status` to return 401, triggering the logged-out screen.

## Test plan
- [x] Launch Electron app - should go directly to main UI without login prompt
- [x] Verify web mode still works with session-based auth

🤖 Generated with [Claude Code](https://claude.com/claude-code)