### PR TITLE
ci: run E2E tests on release candidate branches

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -8,6 +8,7 @@ on:
     branches:
       - main
       - master
+      - 'v*rc' # Run E2E tests on release candidate branches (v0.9.0rc, v1.0.0rc, etc.)
 
 jobs:
   e2e:


### PR DESCRIPTION
## Summary
- Add `v*rc` pattern to E2E tests workflow to automatically run tests on pushes to release candidate branches (v0.9.0rc, v1.0.0rc, etc.)
- This helps catch test failures before merging to main

## Test plan
- [ ] Verify E2E tests run when this PR is merged to v0.9.0rc
- [ ] Confirm the board-background-persistence tests fail (expected - known issue from commit eb627ef3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced continuous integration to automatically run end-to-end tests on release candidate branches, ensuring thorough testing before release.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->