### PR TITLE
fix: allow E2E tests to override settings via localStorage

### DIFF
--- a/apps/ui/scripts/setup-e2e-fixtures.mjs
+++ b/apps/ui/scripts/setup-e2e-fixtures.mjs
@@ -32,7 +32,8 @@ const SPEC_CONTENT = `<app_spec>
 </app_spec>
 `;
 
-// Clean settings.json for E2E tests - no current project so localStorage can control state
+// Clean settings.json for E2E tests
+// localStorageMigrated: false allows tests to override settings via localStorage (addInitScript)
 const E2E_SETTINGS = {
   version: 4,
   setupComplete: true,
@@ -136,17 +137,10 @@ const E2E_SETTINGS = {
       icon: 'Sparkles',
     },
   ],
-  // Default test project using the fixture path - tests can override via route mocking if needed
-  projects: [
-    {
-      id: 'e2e-default-project',
-      name: 'E2E Test Project',
-      path: FIXTURE_PATH,
-      lastOpened: new Date().toISOString(),
-    },
-  ],
+  // Empty projects array - tests control project state via localStorage (addInitScript)
+  projects: [],
   trashedProjects: [],
-  currentProjectId: 'e2e-default-project',
+  currentProjectId: null,
   projectHistory: [],
   projectHistoryIndex: 0,
   lastProjectDir: TEST_WORKSPACE_DIR,
@@ -166,7 +160,7 @@ const E2E_SETTINGS = {
   mcpAutoApproveTools: true,
   mcpUnrestrictedTools: true,
   promptCustomization: {},
-  localStorageMigrated: true,
+  localStorageMigrated: false,
 };
 
 function setupFixtures() {


### PR DESCRIPTION
## Summary
- Set `localStorageMigrated: false` in E2E fixture setup
- Allows tests to use `addInitScript()` to set custom project state via localStorage

## Problem
The `localStorageMigrated: true` setting (added in commit eb627ef3) caused the app to completely ignore localStorage during initialization. This broke E2E tests that relied on setting up custom projects via `addInitScript()`.

The board-background-persistence tests were failing because:
1. Test sets up localStorage with custom project via `addInitScript()`
2. App loads and calls `performSettingsMigration()`
3. With `localStorageMigrated: true`, localStorage is skipped entirely
4. Server's `currentProjectId` takes precedence, ignoring test setup

## Fix
Change `localStorageMigrated: false` so `performSettingsMigration()` will merge localStorage settings with server settings, allowing tests to override the default project.

## Test plan
- [ ] E2E tests pass, specifically `board-background-persistence.spec.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)