### PR TITLE
fix: add TodoWrite to allowed tools in SDK presets

### DIFF
--- a/apps/server/src/lib/sdk-options.ts
+++ b/apps/server/src/lib/sdk-options.ts
@@ -129,10 +129,10 @@ export const TOOL_PRESETS = {
   specGeneration: ['Read', 'Glob', 'Grep'] as const,
 
   /** Full tool access for feature implementation */
-  fullAccess: ['Read', 'Write', 'Edit', 'Glob', 'Grep', 'Bash', 'WebSearch', 'WebFetch'] as const,
+  fullAccess: ['Read', 'Write', 'Edit', 'Glob', 'Grep', 'Bash', 'WebSearch', 'WebFetch', 'TodoWrite'] as const,
 
   /** Tools for chat/interactive mode */
-  chat: ['Read', 'Write', 'Edit', 'Glob', 'Grep', 'Bash', 'WebSearch', 'WebFetch'] as const,
+  chat: ['Read', 'Write', 'Edit', 'Glob', 'Grep', 'Bash', 'WebSearch', 'WebFetch', 'TodoWrite'] as const,
 } as const;
 
 /**


### PR DESCRIPTION
## Summary

- Add `TodoWrite` to `fullAccess` and `chat` tool presets in `sdk-options.ts`

## Problem

The `TodoWrite` tool was missing from the allowed tools list, causing the Claude Agent SDK to crash with exit code 1 when the agent attempted to use it for task tracking during feature implementation.

**Error observed:**
```
Tool Call: TodoWrite
6 todo items

Error
❌ Error: Claude Code process exited with code 1
```

## Solution

Added `TodoWrite` to both `fullAccess` and `chat` tool presets so the Claude agent can use its built-in task tracking capabilities.

## Test plan

- [ ] Start a feature in Auto Mode
- [ ] Verify agent can use TodoWrite without crashing
- [ ] Verify task completes successfully

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * TodoWrite is now available in both full-access and chat modes, expanding the tool set available to users. This enhancement enables TodoWrite functionality across multiple interaction modes, providing broader feature access and supporting more comprehensive user workflows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->