### PR TITLE
feat: Add auto-validate toggle and import dialog for GitHub Issues

### DIFF
--- a/apps/ui/src/components/views/github-issues-view.tsx
+++ b/apps/ui/src/components/views/github-issues-view.tsx
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import { useState, useCallback, useMemo } from 'react';
+import { useState, useCallback, useMemo, useEffect, useRef } from 'react';
 import { createLogger } from '@automaker/utils/logger';
 import { CircleDot, RefreshCw } from 'lucide-react';
 import { getElectronAPI, GitHubIssue, IssueValidationResult } from '@/lib/electron';
@@ -11,7 +11,7 @@ import { cn, pathsEqual } from '@/lib/utils';
 import { toast } from 'sonner';
 import { useGithubIssues, useIssueValidation } from './github-issues-view/hooks';
 import { IssueRow, IssueDetailPanel, IssuesListHeader } from './github-issues-view/components';
-import { ValidationDialog } from './github-issues-view/dialogs';
+import { ValidationDialog, ImportIssuesDialog } from './github-issues-view/dialogs';
 import { formatDate, getFeaturePriority } from './github-issues-view/utils';
 import { useModelOverride } from '@/components/shared';
 import type { ValidateIssueOptions } from './github-issues-view/types';
@@ -23,11 +23,19 @@ export function GitHubIssuesView() {
   const [validationResult, setValidationResult] = useState<IssueValidationResult | null>(null);
   const [showValidationDialog, setShowValidationDialog] = useState(false);
   const [showRevalidateConfirm, setShowRevalidateConfirm] = useState(false);
+  const [showImportDialog, setShowImportDialog] = useState(false);
   const [pendingRevalidateOptions, setPendingRevalidateOptions] =
     useState<ValidateIssueOptions | null>(null);
 
-  const { currentProject, defaultAIProfileId, aiProfiles, getCurrentWorktree, worktreesByProject } =
-    useAppStore();
+  const {
+    currentProject,
+    defaultAIProfileId,
+    aiProfiles,
+    getCurrentWorktree,
+    worktreesByProject,
+    githubAutoValidate,
+    setGithubAutoValidate,
+  } = useAppStore();
 
   // Model override for validation
   const validationModelOverride = useModelOverride({ phase: 'validationModel' });
@@ -44,6 +52,54 @@ export function GitHubIssuesView() {
       onValidationResultChange: setValidationResult,
       onShowValidationDialogChange: setShowValidationDialog,
     });
+
+  // Track which issues we've already triggered auto-validate for (to avoid duplicates)
+  const autoValidatedIssuesRef = useRef<Set<number>>(new Set());
+
+  // Auto-validate issues when enabled and issues are loaded
+  useEffect(() => {
+    if (!githubAutoValidate || loading || openIssues.length === 0) return;
+
+    // Find issues that need validation (not cached and not currently validating)
+    const issuesToValidate = openIssues.filter((issue) => {
+      // Skip if already auto-validated in this session
+      if (autoValidatedIssuesRef.current.has(issue.number)) return false;
+      // Skip if already has cached validation
+      if (cachedValidations.has(issue.number)) return false;
+      // Skip if currently validating
+      if (validatingIssues.has(issue.number)) return false;
+      return true;
+    });
+
+    // Validate up to 3 issues at a time to avoid overwhelming the system
+    const batchSize = 3;
+    const batch = issuesToValidate.slice(0, batchSize);
+
+    for (const issue of batch) {
+      autoValidatedIssuesRef.current.add(issue.number);
+      handleValidateIssue(issue);
+    }
+
+    if (batch.length > 0) {
+      logger.info(
+        `Auto-validating ${batch.length} issues (${issuesToValidate.length - batch.length} remaining)`
+      );
+    }
+  }, [
+    githubAutoValidate,
+    loading,
+    openIssues,
+    cachedValidations,
+    validatingIssues,
+    handleValidateIssue,
+  ]);
+
+  // Reset auto-validated tracking when auto-validate is toggled off
+  useEffect(() => {
+    if (!githubAutoValidate) {
+      autoValidatedIssuesRef.current.clear();
+    }
+  }, [githubAutoValidate]);
 
   // Get default AI profile for task creation
   const defaultProfile = useMemo(() => {
@@ -132,6 +188,42 @@ export function GitHubIssuesView() {
     [currentProject?.path, defaultProfile, currentBranch]
   );
 
+  // Handle bulk import of issues as tasks
+  const handleImportIssues = useCallback(
+    async (issues: GitHubIssue[]) => {
+      if (!currentProject?.path) {
+        toast.error('No project selected');
+        return;
+      }
+
+      let successCount = 0;
+      let errorCount = 0;
+
+      for (const issue of issues) {
+        const validation = cachedValidations.get(issue.number);
+        if (!validation?.result) {
+          errorCount++;
+          continue;
+        }
+
+        try {
+          await handleConvertToTask(issue, validation.result);
+          successCount++;
+        } catch {
+          errorCount++;
+        }
+      }
+
+      if (successCount > 0) {
+        toast.success(`Imported ${successCount} issue${successCount !== 1 ? 's' : ''} as tasks`);
+      }
+      if (errorCount > 0) {
+        toast.error(`Failed to import ${errorCount} issue${errorCount !== 1 ? 's' : ''}`);
+      }
+    },
+    [currentProject?.path, cachedValidations, handleConvertToTask]
+  );
+
   if (loading) {
     return <LoadingState />;
   }
@@ -157,6 +249,9 @@ export function GitHubIssuesView() {
           closedCount={closedIssues.length}
           refreshing={refreshing}
           onRefresh={refresh}
+          autoValidate={githubAutoValidate}
+          onAutoValidateChange={setGithubAutoValidate}
+          onImportClick={() => setShowImportDialog(true)}
         />
 
         {/* Issues List */}
@@ -264,6 +359,16 @@ export function GitHubIssuesView() {
             });
           }
         }}
+      />
+
+      {/* Import Issues Dialog */}
+      <ImportIssuesDialog
+        open={showImportDialog}
+        onOpenChange={setShowImportDialog}
+        issues={openIssues}
+        cachedValidations={cachedValidations}
+        validatingIssues={validatingIssues}
+        onImport={handleImportIssues}
       />
     </div>
   );

--- a/apps/ui/src/components/views/github-issues-view/components/issues-list-header.tsx
+++ b/apps/ui/src/components/views/github-issues-view/components/issues-list-header.tsx
@@ -1,5 +1,7 @@
-import { CircleDot, RefreshCw } from 'lucide-react';
+import { CircleDot, RefreshCw, Zap, Import } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import { Switch } from '@/components/ui/switch';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { cn } from '@/lib/utils';
 
 interface IssuesListHeaderProps {
@@ -7,6 +9,9 @@ interface IssuesListHeaderProps {
   closedCount: number;
   refreshing: boolean;
   onRefresh: () => void;
+  autoValidate: boolean;
+  onAutoValidateChange: (enabled: boolean) => void;
+  onImportClick: () => void;
 }
 
 export function IssuesListHeader({
@@ -14,6 +19,9 @@ export function IssuesListHeader({
   closedCount,
   refreshing,
   onRefresh,
+  autoValidate,
+  onAutoValidateChange,
+  onImportClick,
 }: IssuesListHeaderProps) {
   const totalIssues = openCount + closedCount;
 
@@ -30,9 +38,55 @@ export function IssuesListHeader({
           </p>
         </div>
       </div>
-      <Button variant="outline" size="sm" onClick={onRefresh} disabled={refreshing}>
-        <RefreshCw className={cn('h-4 w-4', refreshing && 'animate-spin')} />
-      </Button>
+      <div className="flex items-center gap-3">
+        {/* Auto-validate toggle */}
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <div className="flex items-center gap-2">
+                <Zap
+                  className={cn(
+                    'h-4 w-4',
+                    autoValidate ? 'text-yellow-500' : 'text-muted-foreground'
+                  )}
+                />
+                <Switch
+                  checked={autoValidate}
+                  onCheckedChange={onAutoValidateChange}
+                  aria-label="Auto-validate issues"
+                />
+              </div>
+            </TooltipTrigger>
+            <TooltipContent>
+              <p>Auto-validate: {autoValidate ? 'ON' : 'OFF'}</p>
+              <p className="text-xs text-muted-foreground">
+                {autoValidate
+                  ? 'Issues are validated automatically when loaded'
+                  : 'Click validate button for each issue'}
+              </p>
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+
+        {/* Import button */}
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button variant="outline" size="sm" onClick={onImportClick}>
+                <Import className="h-4 w-4" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>
+              <p>Import issues as tasks</p>
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+
+        {/* Refresh button */}
+        <Button variant="outline" size="sm" onClick={onRefresh} disabled={refreshing}>
+          <RefreshCw className={cn('h-4 w-4', refreshing && 'animate-spin')} />
+        </Button>
+      </div>
     </div>
   );
 }

--- a/apps/ui/src/components/views/github-issues-view/dialogs/import-issues-dialog.tsx
+++ b/apps/ui/src/components/views/github-issues-view/dialogs/import-issues-dialog.tsx
@@ -1,0 +1,281 @@
+import { useState, useMemo } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Badge } from '@/components/ui/badge';
+import { CheckCircle2, XCircle, AlertCircle, Import, Loader2 } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import type { GitHubIssue, StoredValidation, IssueValidationVerdict } from '@/lib/electron';
+
+interface ImportIssuesDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  issues: GitHubIssue[];
+  cachedValidations: Map<number, StoredValidation>;
+  validatingIssues: Set<number>;
+  onImport: (issues: GitHubIssue[]) => Promise<void>;
+}
+
+const verdictConfig: Record<
+  IssueValidationVerdict,
+  { label: string; color: string; bgColor: string; icon: typeof CheckCircle2 }
+> = {
+  valid: {
+    label: 'Valid',
+    color: 'text-green-500',
+    bgColor: 'bg-green-500/10',
+    icon: CheckCircle2,
+  },
+  invalid: {
+    label: 'Invalid',
+    color: 'text-red-500',
+    bgColor: 'bg-red-500/10',
+    icon: XCircle,
+  },
+  needs_clarification: {
+    label: 'Needs Clarification',
+    color: 'text-yellow-500',
+    bgColor: 'bg-yellow-500/10',
+    icon: AlertCircle,
+  },
+};
+
+export function ImportIssuesDialog({
+  open,
+  onOpenChange,
+  issues,
+  cachedValidations,
+  validatingIssues,
+  onImport,
+}: ImportIssuesDialogProps) {
+  const [selectedIssues, setSelectedIssues] = useState<Set<number>>(new Set());
+  const [importing, setImporting] = useState(false);
+
+  // Filter issues that can be imported (have valid validation)
+  const importableIssues = useMemo(() => {
+    return issues.filter((issue) => {
+      const validation = cachedValidations.get(issue.number);
+      return validation?.result.verdict === 'valid';
+    });
+  }, [issues, cachedValidations]);
+
+  // Count by status
+  const statusCounts = useMemo(() => {
+    let valid = 0;
+    let invalid = 0;
+    let needsClarification = 0;
+    let notValidated = 0;
+
+    for (const issue of issues) {
+      const validation = cachedValidations.get(issue.number);
+      if (!validation) {
+        notValidated++;
+      } else {
+        switch (validation.result.verdict) {
+          case 'valid':
+            valid++;
+            break;
+          case 'invalid':
+            invalid++;
+            break;
+          case 'needs_clarification':
+            needsClarification++;
+            break;
+        }
+      }
+    }
+
+    return { valid, invalid, needsClarification, notValidated };
+  }, [issues, cachedValidations]);
+
+  const handleSelectAll = () => {
+    if (selectedIssues.size === importableIssues.length) {
+      setSelectedIssues(new Set());
+    } else {
+      setSelectedIssues(new Set(importableIssues.map((i) => i.number)));
+    }
+  };
+
+  const handleToggleIssue = (issueNumber: number) => {
+    const newSelected = new Set(selectedIssues);
+    if (newSelected.has(issueNumber)) {
+      newSelected.delete(issueNumber);
+    } else {
+      newSelected.add(issueNumber);
+    }
+    setSelectedIssues(newSelected);
+  };
+
+  const handleImport = async () => {
+    const issuesToImport = issues.filter((i) => selectedIssues.has(i.number));
+    if (issuesToImport.length === 0) return;
+
+    setImporting(true);
+    try {
+      await onImport(issuesToImport);
+      setSelectedIssues(new Set());
+      onOpenChange(false);
+    } finally {
+      setImporting(false);
+    }
+  };
+
+  // Reset selection when dialog opens
+  const handleOpenChange = (newOpen: boolean) => {
+    if (!newOpen) {
+      setSelectedIssues(new Set());
+    }
+    onOpenChange(newOpen);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="max-w-2xl max-h-[80vh] flex flex-col">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Import className="h-5 w-5" />
+            Import Issues as Tasks
+          </DialogTitle>
+          <DialogDescription>
+            Select validated issues to import as tasks into your backlog.
+          </DialogDescription>
+        </DialogHeader>
+
+        {/* Status Summary */}
+        <div className="flex flex-wrap gap-2 py-2 border-b border-border">
+          <Badge variant="outline" className="text-green-500 border-green-500/30">
+            {statusCounts.valid} valid
+          </Badge>
+          <Badge variant="outline" className="text-yellow-500 border-yellow-500/30">
+            {statusCounts.needsClarification} needs clarification
+          </Badge>
+          <Badge variant="outline" className="text-red-500 border-red-500/30">
+            {statusCounts.invalid} invalid
+          </Badge>
+          <Badge variant="outline" className="text-muted-foreground">
+            {statusCounts.notValidated} not validated
+          </Badge>
+        </div>
+
+        {/* Issues List */}
+        <div className="flex-1 overflow-y-auto min-h-[200px] max-h-[400px]">
+          {issues.length === 0 ? (
+            <div className="flex flex-col items-center justify-center h-full text-center py-8">
+              <AlertCircle className="h-8 w-8 text-muted-foreground mb-4" />
+              <p className="text-sm text-muted-foreground">No open issues found.</p>
+            </div>
+          ) : (
+            <div className="space-y-1 py-2">
+              {issues.map((issue) => {
+                const validation = cachedValidations.get(issue.number);
+                const isValidating = validatingIssues.has(issue.number);
+                const isImportable = validation?.result.verdict === 'valid';
+                const isSelected = selectedIssues.has(issue.number);
+
+                return (
+                  <div
+                    key={issue.number}
+                    className={cn(
+                      'flex items-center gap-3 p-3 rounded-lg border transition-colors',
+                      isImportable
+                        ? 'hover:bg-muted/50 cursor-pointer'
+                        : 'opacity-50 cursor-not-allowed',
+                      isSelected && 'bg-primary/10 border-primary/30'
+                    )}
+                    onClick={() => isImportable && handleToggleIssue(issue.number)}
+                  >
+                    <Checkbox
+                      checked={isSelected}
+                      disabled={!isImportable}
+                      onCheckedChange={() => isImportable && handleToggleIssue(issue.number)}
+                    />
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center gap-2">
+                        <span className="text-sm font-medium text-muted-foreground">
+                          #{issue.number}
+                        </span>
+                        <span className="text-sm font-medium truncate">{issue.title}</span>
+                      </div>
+                      {issue.labels.length > 0 && (
+                        <div className="flex flex-wrap gap-1 mt-1">
+                          {issue.labels.slice(0, 3).map((label) => (
+                            <Badge key={label.name} variant="outline" className="text-xs">
+                              {label.name}
+                            </Badge>
+                          ))}
+                          {issue.labels.length > 3 && (
+                            <Badge variant="outline" className="text-xs">
+                              +{issue.labels.length - 3}
+                            </Badge>
+                          )}
+                        </div>
+                      )}
+                    </div>
+                    <div className="flex items-center gap-2 shrink-0">
+                      {isValidating ? (
+                        <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+                      ) : validation ? (
+                        (() => {
+                          const config = verdictConfig[validation.result.verdict];
+                          const Icon = config.icon;
+                          return (
+                            <div className={cn('flex items-center gap-1', config.color)}>
+                              <Icon className="h-4 w-4" />
+                              <span className="text-xs">{config.label}</span>
+                            </div>
+                          );
+                        })()
+                      ) : (
+                        <span className="text-xs text-muted-foreground">Not validated</span>
+                      )}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
+
+        <DialogFooter className="border-t border-border pt-4">
+          <div className="flex items-center justify-between w-full">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={handleSelectAll}
+              disabled={importableIssues.length === 0}
+            >
+              {selectedIssues.size === importableIssues.length && importableIssues.length > 0
+                ? 'Deselect All'
+                : `Select All Valid (${importableIssues.length})`}
+            </Button>
+            <div className="flex gap-2">
+              <Button variant="ghost" onClick={() => handleOpenChange(false)}>
+                Cancel
+              </Button>
+              <Button onClick={handleImport} disabled={selectedIssues.size === 0 || importing}>
+                {importing ? (
+                  <>
+                    <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                    Importing...
+                  </>
+                ) : (
+                  <>
+                    <Import className="h-4 w-4 mr-2" />
+                    Import {selectedIssues.size} Issue{selectedIssues.size !== 1 ? 's' : ''}
+                  </>
+                )}
+              </Button>
+            </div>
+          </div>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/ui/src/components/views/github-issues-view/dialogs/index.ts
+++ b/apps/ui/src/components/views/github-issues-view/dialogs/index.ts
@@ -1,1 +1,2 @@
 export { ValidationDialog } from './validation-dialog';
+export { ImportIssuesDialog } from './import-issues-dialog';

--- a/apps/ui/src/store/app-store.ts
+++ b/apps/ui/src/store/app-store.ts
@@ -557,6 +557,9 @@ export interface AppState {
   // Validation Model Settings
   validationModel: ModelAlias; // Model used for GitHub issue validation (default: opus)
 
+  // GitHub Auto-Validate Settings
+  githubAutoValidate: boolean; // When true, automatically validate issues when viewing GitHub Issues tab
+
   // Phase Model Settings - per-phase AI model configuration
   phaseModels: PhaseModelConfig;
   favoriteModels: string[];
@@ -924,6 +927,9 @@ export interface AppActions {
   // Validation Model actions
   setValidationModel: (model: ModelAlias) => void;
 
+  // GitHub Auto-Validate actions
+  setGithubAutoValidate: (enabled: boolean) => void;
+
   // Phase Model actions
   setPhaseModel: (phase: PhaseModelKey, entry: PhaseModelEntry) => Promise<void>;
   setPhaseModels: (models: Partial<PhaseModelConfig>) => Promise<void>;
@@ -1180,6 +1186,7 @@ const initialState: AppState = {
   muteDoneSound: false, // Default to sound enabled (not muted)
   enhancementModel: 'sonnet', // Default to sonnet for feature enhancement
   validationModel: 'opus', // Default to opus for GitHub issue validation
+  githubAutoValidate: false, // Default to disabled (manual validation only)
   phaseModels: DEFAULT_PHASE_MODELS, // Phase-specific model configuration
   favoriteModels: [],
   enabledCursorModels: getAllCursorModelIds(), // All Cursor models enabled by default
@@ -1842,6 +1849,9 @@ export const useAppStore = create<AppState & AppActions>()((set, get) => ({
 
   // Validation Model actions
   setValidationModel: (model) => set({ validationModel: model }),
+
+  // GitHub Auto-Validate actions
+  setGithubAutoValidate: (enabled) => set({ githubAutoValidate: enabled }),
 
   // Phase Model actions
   setPhaseModel: async (phase, entry) => {


### PR DESCRIPTION
## Summary
- Add auto-validate toggle to GitHub Issues tab header
- Add import dialog for bulk importing GitHub issues as tasks

## Changes
- **Auto-validate toggle**: When enabled, automatically validates open issues in batches of 3 when the Issues tab is loaded
- **Import dialog**: Allows bulk selection and import of validated issues as tasks
  - Shows status summary (valid/invalid/needs clarification/not validated)
  - Only issues with "valid" validation can be imported
  - "Select All Valid" button for convenience

## Test plan
- [ ] Open GitHub Issues tab
- [ ] Toggle auto-validate ON and verify issues start validating automatically
- [ ] Toggle auto-validate OFF and verify no more auto-validation occurs
- [ ] Click Import button and verify dialog shows all issues with their validation status
- [ ] Select valid issues and verify they import successfully as tasks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Automatic GitHub issue validation in batches for improved efficiency
- Bulk import capability to convert validated GitHub issues into tasks
- New auto-validate toggle in the issues toolbar for easy control
- Import dialog displaying per-issue validation status with select-all functionality

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->