### PR TITLE
fix: add OpenCode cache volume for version file persistence

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -90,6 +90,9 @@ services:
       # Persist OpenCode user configuration across container restarts
       - automaker-opencode-config:/home/automaker/.config/opencode
 
+      # Persist OpenCode cache directory (contains version file and other cache data)
+      - automaker-opencode-cache:/home/automaker/.cache/opencode
+
       # NO host directory mounts - container cannot access your laptop files
       # If you need to work on a project, create it INSIDE the container
       # or use a separate docker-compose override file
@@ -123,3 +126,8 @@ volumes:
     name: automaker-opencode-config
     # Named volume for OpenCode user configuration (~/.config/opencode)
     # Persists user configuration across container restarts
+
+  automaker-opencode-cache:
+    name: automaker-opencode-cache
+    # Named volume for OpenCode cache directory (~/.cache/opencode)
+    # Contains version file and other cached data

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -40,6 +40,13 @@ fi
 chown -R automaker:automaker /home/automaker/.config/opencode
 chmod -R 700 /home/automaker/.config/opencode
 
+# OpenCode also uses ~/.cache/opencode for cache data (version file, etc.)
+if [ ! -d "/home/automaker/.cache/opencode" ]; then
+    mkdir -p /home/automaker/.cache/opencode
+fi
+chown -R automaker:automaker /home/automaker/.cache/opencode
+chmod -R 700 /home/automaker/.cache/opencode
+
 # If CURSOR_AUTH_TOKEN is set, write it to the cursor auth file
 # On Linux, cursor-agent uses ~/.config/cursor/auth.json for file-based credential storage
 # The env var CURSOR_AUTH_TOKEN is also checked directly by cursor-agent


### PR DESCRIPTION
## Problem

After PR #460 was merged, OpenCode CLI was failing with:

```
EACCES: permission denied, open '/home/automaker/.cache/opencode/version'
```

OpenCode uses **three** XDG directories but PR #460 only mounted two:
- `~/.local/share/opencode` ✅ Mounted
- `~/.config/opencode` ✅ Mounted
- `~/.cache/opencode` ❌ **Missing** - stores version file

## Solution

- Add `automaker-opencode-cache` volume mount for `~/.cache/opencode`
- Add entrypoint script handling to set correct ownership/permissions on the cache directory