### PR TITLE
fix: ensure npm cache directory has correct permissions

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -47,6 +47,13 @@ fi
 chown -R automaker:automaker /home/automaker/.cache/opencode
 chmod -R 700 /home/automaker/.cache/opencode
 
+# Ensure npm cache directory exists with correct permissions
+# This is needed for using npx to run MCP servers
+if [ ! -d "/home/automaker/.npm" ]; then
+    mkdir -p /home/automaker/.npm
+fi
+chown -R automaker:automaker /home/automaker/.npm
+
 # If CURSOR_AUTH_TOKEN is set, write it to the cursor auth file
 # On Linux, cursor-agent uses ~/.config/cursor/auth.json for file-based credential storage
 # The env var CURSOR_AUTH_TOKEN is also checked directly by cursor-agent


### PR DESCRIPTION
## Summary

Fix EACCES permission error when running npx commands (e.g., MCP servers) inside the Docker container.

## Problem

When running `npx` commands inside the container (such as starting MCP servers), the following error occurred:

```
npm error code EACCES
npm error syscall mkdir
npm error path /home/automaker/.npm/_cacache/index-v5/1f/fc
npm error errno EACCES
npm error
npm error Your cache folder contains root-owned files, due to a bug in
npm error previous versions of npm which has since been addressed.
npm error
npm error To permanently fix this problem, please run:
npm error   sudo chown -R 1001:1001 "/home/automaker/.npm"
```

## Solution

Added handling in `docker-entrypoint.sh` to ensure the `/home/automaker/.npm` directory exists and has correct ownership before switching to the automaker user.

## Changes

- Added npm cache directory creation and permission fix in entrypoint script

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced unified Simple Query Service API for provider-agnostic AI interactions
  * Added pipeline-aware feature resume capability with step detection
  * Added default feature model setting for new features
  * Integrated OpenCode CLI alongside Cursor CLI

* **Bug Fixes**
  * Fixed file permission issues via Docker UID/GID host alignment
  * Enhanced security for external URL navigation with noopener/noreferrer flags

* **Improvements**
  * Refactored provider-specific branching to use unified query interface
  * Improved UI accessibility and text clarity in settings
  * Enhanced Docker volume persistence for OpenCode and npm caches
  * Updated settings synchronization for model defaults

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->