### PR TITLE
fix: Resolve windows npx spawn errors

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -31,7 +31,12 @@ fi
 
 # Ensure common system paths are in PATH (for systems without nvm)
 # This helps find node/npm installed via Homebrew, system packages, etc.
-export PATH="$PATH:/usr/local/bin:/opt/homebrew/bin:/usr/bin"
+if [ -n "$WINDIR" ]; then
+  export PATH="$PATH:/c/Program Files/nodejs:/c/Program Files (x86)/nodejs"
+  export PATH="$PATH:$APPDATA/npm:$LOCALAPPDATA/Programs/nodejs"
+else 
+  export PATH="$PATH:/usr/local/bin:/opt/homebrew/bin:/usr/bin"
+fi
 
 # Run lint-staged - works with or without nvm
 # Prefer npx, fallback to npm exec, both work with system-installed Node.js

--- a/apps/server/src/providers/opencode-provider.ts
+++ b/apps/server/src/providers/opencode-provider.ts
@@ -730,7 +730,7 @@ export class OpencodeProvider extends CliProvider {
 
       if (this.detectedStrategy === 'npx') {
         // NPX strategy: execute npx with opencode-ai package
-        command = 'npx';
+        command = process.platform === 'win32' ? 'npx.cmd' : 'npx';
         args = ['opencode-ai@latest', 'models'];
         opencodeLogger.debug(`Executing: ${command} ${args.join(' ')}`);
       } else if (this.useWsl && this.wslCliPath) {
@@ -751,6 +751,8 @@ export class OpencodeProvider extends CliProvider {
         encoding: 'utf-8',
         timeout: 30000,
         windowsHide: true,
+        // Use shell on Windows for .cmd files
+        shell: process.platform === 'win32' && command.endsWith('.cmd'),
       });
 
       opencodeLogger.debug(
@@ -963,7 +965,7 @@ export class OpencodeProvider extends CliProvider {
 
       if (this.detectedStrategy === 'npx') {
         // NPX strategy
-        command = 'npx';
+        command = process.platform === 'win32' ? 'npx.cmd' : 'npx';
         args = ['opencode-ai@latest', 'auth', 'list'];
         opencodeLogger.debug(`Executing: ${command} ${args.join(' ')}`);
       } else if (this.useWsl && this.wslCliPath) {
@@ -984,6 +986,8 @@ export class OpencodeProvider extends CliProvider {
         encoding: 'utf-8',
         timeout: 15000,
         windowsHide: true,
+        // Use shell on Windows for .cmd files
+        shell: process.platform === 'win32' && command.endsWith('.cmd'),
       });
 
       opencodeLogger.debug(

--- a/libs/platform/src/subprocess.ts
+++ b/libs/platform/src/subprocess.ts
@@ -45,7 +45,9 @@ export async function* spawnJSONLProcess(options: SubprocessOptions): AsyncGener
   }
 
   // On Windows, .cmd files must be run through shell (cmd.exe)
-  const needsShell = process.platform === 'win32' && command.toLowerCase().endsWith('.cmd');
+  const needsShell =
+    process.platform === 'win32' &&
+    (command.toLowerCase().endsWith('.cmd') || command === 'npx' || command === 'npm');
 
   const childProcess: ChildProcess = spawn(command, args, {
     cwd,
@@ -199,7 +201,9 @@ export async function spawnProcess(options: SubprocessOptions): Promise<Subproce
 
   return new Promise((resolve, reject) => {
     // On Windows, .cmd files must be run through shell (cmd.exe)
-    const needsShell = process.platform === 'win32' && command.toLowerCase().endsWith('.cmd');
+    const needsShell =
+      process.platform === 'win32' &&
+      (command.toLowerCase().endsWith('.cmd') || command === 'npx' || command === 'npm');
 
     const childProcess = spawn(command, args, {
       cwd,


### PR DESCRIPTION
## Summary

Fixed a spawn of opencode via NPX on Windows devices. Was giving an error
`ERROR [Server] Uncaught Exception: {
  message: 'spawn npx ENOENT',
  stack: 'Error: spawn npx ENOENT\n' +
    '    at ChildProcess._handle.onexit (node:internal/child_process:286:19)\n' +
    '    at onErrorNT (node:internal/child_process:484:16)\n' +
    '    at process.processTicksAndRejections (node:internal/process/task_queues:89:21)'
}`

After changes in this PR getting providers, models from CLI and also spawning the opencode process itself is working. 



Also added a support for windows machines for pre-commit hook.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows compatibility for npm/npx command execution by using appropriate executable formats on Windows systems.
  * Fixed PATH configuration to properly detect Node.js and npm installations on Windows environments.
  * Enhanced subprocess handling to ensure proper execution of commands on Windows platforms.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->