### PR TITLE
chore(docker): add Playwright Chromium prerequisites

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,8 +65,16 @@ ARG UID=1001
 ARG GID=1001
 
 # Install git, curl, bash (for terminal), gosu (for user switching), and GitHub CLI (pinned version, multi-arch)
+# Also install Playwright/Chromium system dependencies (aligns with playwright install-deps on Debian/Ubuntu)
 RUN apt-get update && apt-get install -y --no-install-recommends \
     git curl bash gosu ca-certificates openssh-client \
+    # Playwright/Chromium dependencies
+    libglib2.0-0 libnss3 libnspr4 libdbus-1-3 libatk1.0-0 libatk-bridge2.0-0 \
+    libcups2 libdrm2 libxkbcommon0 libatspi2.0-0 libxcomposite1 libxdamage1 \
+    libxfixes3 libxrandr2 libgbm1 libasound2 libpango-1.0-0 libcairo2 \
+    libx11-6 libx11-xcb1 libxcb1 libxext6 libxrender1 libxss1 libxtst6 \
+    libxshmfence1 libgtk-3-0 libexpat1 libfontconfig1 fonts-liberation \
+    xdg-utils libpangocairo-1.0-0 libpangoft2-1.0-0 libu2f-udev libvulkan1 \
     && GH_VERSION="2.63.2" \
     && ARCH=$(uname -m) \
     && case "$ARCH" in \

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -8,9 +8,17 @@
 FROM node:22-slim
 
 # Install build dependencies for native modules (node-pty) and runtime tools
+# Also install Playwright/Chromium system dependencies (aligns with playwright install-deps on Debian/Ubuntu)
 RUN apt-get update && apt-get install -y --no-install-recommends \
     python3 make g++ \
     git curl bash gosu ca-certificates openssh-client \
+    # Playwright/Chromium dependencies
+    libglib2.0-0 libnss3 libnspr4 libdbus-1-3 libatk1.0-0 libatk-bridge2.0-0 \
+    libcups2 libdrm2 libxkbcommon0 libatspi2.0-0 libxcomposite1 libxdamage1 \
+    libxfixes3 libxrandr2 libgbm1 libasound2 libpango-1.0-0 libcairo2 \
+    libx11-6 libx11-xcb1 libxcb1 libxext6 libxrender1 libxss1 libxtst6 \
+    libxshmfence1 libgtk-3-0 libexpat1 libfontconfig1 fonts-liberation \
+    xdg-utils libpangocairo-1.0-0 libpangoft2-1.0-0 libu2f-udev libvulkan1 \
     && GH_VERSION="2.63.2" \
     && ARCH=$(uname -m) \
     && case "$ARCH" in \

--- a/docker-compose.override.yml.example
+++ b/docker-compose.override.yml.example
@@ -21,6 +21,9 @@ services:
       # - ~/.local/share/opencode:/home/automaker/.local/share/opencode
       # - ~/.config/opencode:/home/automaker/.config/opencode
 
+      # Playwright browser cache - persists installed browsers across container restarts
+      # Run 'npx playwright install --with-deps chromium' once, and it will persist
+      # - playwright-cache:/home/automaker/.cache/ms-playwright
     environment:
       # Set root directory for all projects and file operations
       # Users can only create/open projects within this directory
@@ -32,3 +35,8 @@ services:
       # Extract your Cursor token with: ./scripts/get-cursor-token.sh
       # Then set it here or in your .env file:
       # - CURSOR_API_KEY=${CURSOR_API_KEY:-}
+
+volumes:
+  # Playwright cache volume (persists Chromium installs)
+  # playwright-cache:
+  #   name: automaker-playwright-cache


### PR DESCRIPTION
This PR adds missing Debian system libraries required for Playwright/Chromium to run inside the Automaker Docker images, and documents an optional cache volume for persisting downloaded Playwright browsers.

Changes:
- Install Playwright/Chromium runtime dependencies in Dockerfile (server image)
- Install the same dependencies in Dockerfile.dev (dev image)
- Add an example playwright-cache volume mount and volume definition stub in docker-compose.override.yml.example to persist /home/automaker/.cache/ms-playwright

Why:
E2E tests (and any browser automation) rely on Playwright + Chromium. Without these system libraries, Chromium can fail to launch in slim Debian images.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container build configurations to include system dependencies for browser automation support in production and development environments.
  * Added optional cache persistence guidance in development setup documentation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->