### PR TITLE
Add OpenCode CLI Provider Support to ModelSelector

### DIFF
--- a/apps/ui/src/components/views/board-view/shared/model-selector.tsx
+++ b/apps/ui/src/components/views/board-view/shared/model-selector.tsx
@@ -1,17 +1,207 @@
 // @ts-nocheck
 import { Label } from '@/components/ui/label';
 import { Badge } from '@/components/ui/badge';
-import { Brain, AlertTriangle } from 'lucide-react';
+import { Brain, AlertTriangle, RefreshCw } from 'lucide-react';
 import { AnthropicIcon, CursorIcon, OpenAIIcon, OpenCodeIcon } from '@/components/ui/provider-icon';
 import { cn } from '@/lib/utils';
 import type { ModelAlias } from '@/store/app-store';
 import { useAppStore } from '@/store/app-store';
 import { useSetupStore } from '@/store/setup-store';
-import { getModelProvider, PROVIDER_PREFIXES, stripProviderPrefix } from '@automaker/types';
+import {
+  getModelProvider,
+  PROVIDER_PREFIXES,
+  stripProviderPrefix,
+  DEFAULT_OPENCODE_MODEL,
+} from '@automaker/types';
 import type { ModelProvider } from '@automaker/types';
 import { CLAUDE_MODELS, CURSOR_MODELS, ModelOption } from './model-constants';
-import { useEffect } from 'react';
-import { RefreshCw } from 'lucide-react';
+import { useEffect, useCallback } from 'react';
+
+// Badge mappings for model tiers
+const CODEX_BADGE_MAP: Record<string, string> = {
+  premium: 'Premium',
+  basic: 'Speed',
+  standard: 'Balanced',
+};
+
+const OPENCODE_BADGE_MAP: Record<string, string> = {
+  premium: 'Premium',
+  basic: 'Free',
+  standard: 'Balanced',
+};
+
+/**
+ * Custom hook to fetch provider models when available
+ */
+function useProviderModels(
+  isAvailable: boolean,
+  modelsLength: number,
+  isLoading: boolean,
+  fetcher: () => void
+) {
+  useEffect(() => {
+    if (isAvailable && modelsLength === 0 && !isLoading) {
+      fetcher();
+    }
+  }, [isAvailable, modelsLength, isLoading, fetcher]);
+}
+
+/**
+ * Transform raw provider models to ModelOption format
+ */
+function transformModels<
+  T extends {
+    id: string;
+    tier?: string;
+    hasThinking?: boolean;
+    name?: string;
+    label?: string;
+    description?: string;
+  },
+>(
+  models: T[],
+  provider: ModelProvider,
+  badgeMap: Record<string, string>,
+  defaultHasThinking = false
+): ModelOption[] {
+  return models.map((model) => ({
+    id: model.id,
+    label: model.name || model.label || model.id,
+    description: model.description || '',
+    badge: model.tier ? badgeMap[model.tier] : undefined,
+    provider,
+    hasThinking: model.hasThinking ?? defaultHasThinking,
+  }));
+}
+
+interface DynamicModelListProps {
+  models: ModelOption[];
+  selectedModel: string;
+  onModelSelect: (model: string) => void;
+  testIdPrefix: string;
+  isLoading: boolean;
+  error: string | null;
+  onRetry: () => void;
+  emptyMessage: string;
+  badgeColorClass?: string;
+  thinkingBadgeColorClass?: string;
+  showThinkingBadge?: boolean;
+}
+
+/**
+ * Reusable component for displaying a list of dynamic models
+ */
+function DynamicModelList({
+  models,
+  selectedModel,
+  onModelSelect,
+  testIdPrefix,
+  isLoading,
+  error,
+  onRetry,
+  emptyMessage,
+  badgeColorClass = 'border-muted-foreground/50 text-muted-foreground',
+  thinkingBadgeColorClass = 'border-amber-500/50 text-amber-600 dark:text-amber-400',
+  showThinkingBadge = false,
+}: DynamicModelListProps) {
+  // Loading state
+  if (isLoading && models.length === 0) {
+    return (
+      <div className="flex items-center justify-center gap-2 p-6 text-sm text-muted-foreground">
+        <RefreshCw className="w-4 h-4 animate-spin" />
+        Loading models...
+      </div>
+    );
+  }
+
+  // Error state
+  if (error && !isLoading) {
+    return (
+      <div className="flex items-start gap-2 p-3 rounded-lg bg-red-500/10 border border-red-500/20">
+        <AlertTriangle className="w-4 h-4 text-red-400 mt-0.5 shrink-0" />
+        <div className="space-y-1">
+          <div className="text-sm text-red-400">Failed to load models</div>
+          <button
+            type="button"
+            onClick={onRetry}
+            className="text-xs text-red-400 underline hover:no-underline"
+          >
+            Retry
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  // Empty state
+  if (!isLoading && !error && models.length === 0) {
+    return (
+      <div className="text-sm text-muted-foreground p-3 border border-dashed rounded-md text-center">
+        {emptyMessage}
+      </div>
+    );
+  }
+
+  // Model list
+  if (!isLoading && models.length > 0) {
+    return (
+      <div className="flex flex-col gap-2 max-h-[300px] overflow-y-auto">
+        {models.map((option) => {
+          const isSelected = selectedModel === option.id;
+          return (
+            <button
+              key={option.id}
+              type="button"
+              onClick={() => onModelSelect(option.id)}
+              title={option.description}
+              className={cn(
+                'w-full px-3 py-2 rounded-md border text-sm font-medium transition-colors flex items-center justify-between',
+                isSelected
+                  ? 'bg-primary text-primary-foreground border-primary'
+                  : 'bg-background hover:bg-accent border-border'
+              )}
+              data-testid={`${testIdPrefix}-${option.id}`}
+            >
+              <span className="truncate">{option.label}</span>
+              <div className="flex gap-1 shrink-0">
+                {showThinkingBadge && option.hasThinking && (
+                  <Badge
+                    variant="outline"
+                    className={cn(
+                      'text-xs',
+                      isSelected
+                        ? 'border-primary-foreground/50 text-primary-foreground'
+                        : thinkingBadgeColorClass
+                    )}
+                  >
+                    Thinking
+                  </Badge>
+                )}
+                {option.badge && (
+                  <Badge
+                    variant="outline"
+                    className={cn(
+                      'text-xs',
+                      isSelected
+                        ? 'border-primary-foreground/50 text-primary-foreground'
+                        : option.badge === 'Free'
+                          ? 'border-green-500/50 text-green-600 dark:text-green-400'
+                          : badgeColorClass
+                    )}
+                  >
+                    {option.badge}
+                  </Badge>
+                )}
+              </div>
+            </button>
+          );
+        })}
+      </div>
+    );
+  }
+
+  return null;
+}
 
 interface ModelSelectorProps {
   selectedModel: string; // Can be ModelAlias or "cursor-{id}"
@@ -50,60 +240,22 @@ export function ModelSelector({
   const isOpencodeAvailable =
     opencodeCliStatus?.installed && opencodeCliStatus?.auth?.authenticated;
 
-  // Fetch Codex models on mount
-  useEffect(() => {
-    if (isCodexAvailable && codexModels.length === 0 && !codexModelsLoading) {
-      fetchCodexModels();
-    }
-  }, [isCodexAvailable, codexModels.length, codexModelsLoading, fetchCodexModels]);
-
-  // Fetch OpenCode models on mount
-  useEffect(() => {
-    if (isOpencodeAvailable && dynamicOpencodeModels.length === 0 && !opencodeModelsLoading) {
-      fetchOpencodeModels();
-    }
-  }, [
+  // Fetch provider models on mount using custom hook
+  useProviderModels(isCodexAvailable, codexModels.length, codexModelsLoading, fetchCodexModels);
+  useProviderModels(
     isOpencodeAvailable,
     dynamicOpencodeModels.length,
     opencodeModelsLoading,
-    fetchOpencodeModels,
-  ]);
+    fetchOpencodeModels
+  );
 
-  // Transform codex models from store to ModelOption format
-  const dynamicCodexModels: ModelOption[] = codexModels.map((model) => {
-    // Infer badge based on tier
-    let badge: string | undefined;
-    if (model.tier === 'premium') badge = 'Premium';
-    else if (model.tier === 'basic') badge = 'Speed';
-    else if (model.tier === 'standard') badge = 'Balanced';
-
-    return {
-      id: model.id,
-      label: model.label,
-      description: model.description,
-      badge,
-      provider: 'codex' as ModelProvider,
-      hasThinking: model.hasThinking,
-    };
-  });
-
-  // Transform opencode models from store to ModelOption format
-  const transformedOpencodeModels: ModelOption[] = dynamicOpencodeModels.map((model) => {
-    // Infer badge based on tier
-    let badge: string | undefined;
-    if (model.tier === 'premium') badge = 'Premium';
-    else if (model.tier === 'basic') badge = 'Free';
-    else if (model.tier === 'standard') badge = 'Balanced';
-
-    return {
-      id: model.id,
-      label: model.name,
-      description: model.description || '',
-      badge,
-      provider: 'opencode' as ModelProvider,
-      hasThinking: false,
-    };
-  });
+  // Transform models using helper function
+  const transformedCodexModels = transformModels(codexModels, 'codex', CODEX_BADGE_MAP);
+  const transformedOpencodeModels = transformModels(
+    dynamicOpencodeModels,
+    'opencode',
+    OPENCODE_BADGE_MAP
+  );
 
   // Filter Cursor models based on enabled models from global settings
   const filteredCursorModels = CURSOR_MODELS.filter((model) => {
@@ -125,7 +277,7 @@ export function ModelSelector({
       // Switch to OpenCode's default model
       const defaultModel = dynamicOpencodeModels.find((m) => m.default);
       const defaultModelId =
-        defaultModel?.id || dynamicOpencodeModels[0]?.id || 'opencode/big-pickle';
+        defaultModel?.id || dynamicOpencodeModels[0]?.id || DEFAULT_OPENCODE_MODEL;
       onModelSelect(defaultModelId);
     } else if (provider === 'claude' && selectedProvider !== 'claude') {
       // Switch to Claude's default model
@@ -329,82 +481,17 @@ export function ModelSelector({
             </span>
           </div>
 
-          {/* Loading state */}
-          {opencodeModelsLoading && transformedOpencodeModels.length === 0 && (
-            <div className="flex items-center justify-center gap-2 p-6 text-sm text-muted-foreground">
-              <RefreshCw className="w-4 h-4 animate-spin" />
-              Loading models...
-            </div>
-          )}
-
-          {/* Error state */}
-          {opencodeModelsError && !opencodeModelsLoading && (
-            <div className="flex items-start gap-2 p-3 rounded-lg bg-red-500/10 border border-red-500/20">
-              <AlertTriangle className="w-4 h-4 text-red-400 mt-0.5 shrink-0" />
-              <div className="space-y-1">
-                <div className="text-sm text-red-400">Failed to load OpenCode models</div>
-                <button
-                  type="button"
-                  onClick={() => fetchOpencodeModels(true)}
-                  className="text-xs text-red-400 underline hover:no-underline"
-                >
-                  Retry
-                </button>
-              </div>
-            </div>
-          )}
-
-          {/* Model list */}
-          {!opencodeModelsLoading &&
-            !opencodeModelsError &&
-            transformedOpencodeModels.length === 0 && (
-              <div className="text-sm text-muted-foreground p-3 border border-dashed rounded-md text-center">
-                No OpenCode models available. Make sure you're logged in with GitHub Copilot or
-                other providers.
-              </div>
-            )}
-
-          {!opencodeModelsLoading && transformedOpencodeModels.length > 0 && (
-            <div className="flex flex-col gap-2 max-h-[300px] overflow-y-auto">
-              {transformedOpencodeModels.map((option) => {
-                const isSelected = selectedModel === option.id;
-                return (
-                  <button
-                    key={option.id}
-                    type="button"
-                    onClick={() => onModelSelect(option.id)}
-                    title={option.description}
-                    className={cn(
-                      'w-full px-3 py-2 rounded-md border text-sm font-medium transition-colors flex items-center justify-between',
-                      isSelected
-                        ? 'bg-primary text-primary-foreground border-primary'
-                        : 'bg-background hover:bg-accent border-border'
-                    )}
-                    data-testid={`${testIdPrefix}-${option.id}`}
-                  >
-                    <span className="truncate">{option.label}</span>
-                    <div className="flex gap-1 shrink-0">
-                      {option.badge && (
-                        <Badge
-                          variant="outline"
-                          className={cn(
-                            'text-xs',
-                            isSelected
-                              ? 'border-primary-foreground/50 text-primary-foreground'
-                              : option.badge === 'Free'
-                                ? 'border-green-500/50 text-green-600 dark:text-green-400'
-                                : 'border-muted-foreground/50 text-muted-foreground'
-                          )}
-                        >
-                          {option.badge}
-                        </Badge>
-                      )}
-                    </div>
-                  </button>
-                );
-              })}
-            </div>
-          )}
+          <DynamicModelList
+            models={transformedOpencodeModels}
+            selectedModel={selectedModel}
+            onModelSelect={onModelSelect}
+            testIdPrefix={testIdPrefix}
+            isLoading={opencodeModelsLoading}
+            error={opencodeModelsError}
+            onRetry={() => fetchOpencodeModels(true)}
+            emptyMessage="No OpenCode models available. Make sure you're logged in with GitHub Copilot or other providers."
+            badgeColorClass="border-muted-foreground/50 text-muted-foreground"
+          />
         </div>
       )}
 
@@ -432,90 +519,19 @@ export function ModelSelector({
             </span>
           </div>
 
-          {/* Loading state */}
-          {codexModelsLoading && dynamicCodexModels.length === 0 && (
-            <div className="flex items-center justify-center gap-2 p-6 text-sm text-muted-foreground">
-              <RefreshCw className="w-4 h-4 animate-spin" />
-              Loading models...
-            </div>
-          )}
-
-          {/* Error state */}
-          {codexModelsError && !codexModelsLoading && (
-            <div className="flex items-start gap-2 p-3 rounded-lg bg-red-500/10 border border-red-500/20">
-              <AlertTriangle className="w-4 h-4 text-red-400 mt-0.5 shrink-0" />
-              <div className="space-y-1">
-                <div className="text-sm text-red-400">Failed to load Codex models</div>
-                <button
-                  type="button"
-                  onClick={() => fetchCodexModels(true)}
-                  className="text-xs text-red-400 underline hover:no-underline"
-                >
-                  Retry
-                </button>
-              </div>
-            </div>
-          )}
-
-          {/* Model list */}
-          {!codexModelsLoading && !codexModelsError && dynamicCodexModels.length === 0 && (
-            <div className="text-sm text-muted-foreground p-3 border border-dashed rounded-md text-center">
-              No Codex models available
-            </div>
-          )}
-
-          {!codexModelsLoading && dynamicCodexModels.length > 0 && (
-            <div className="flex flex-col gap-2">
-              {dynamicCodexModels.map((option) => {
-                const isSelected = selectedModel === option.id;
-                return (
-                  <button
-                    key={option.id}
-                    type="button"
-                    onClick={() => onModelSelect(option.id)}
-                    title={option.description}
-                    className={cn(
-                      'w-full px-3 py-2 rounded-md border text-sm font-medium transition-colors flex items-center justify-between',
-                      isSelected
-                        ? 'bg-primary text-primary-foreground border-primary'
-                        : 'bg-background hover:bg-accent border-border'
-                    )}
-                    data-testid={`${testIdPrefix}-${option.id}`}
-                  >
-                    <span>{option.label}</span>
-                    <div className="flex gap-1">
-                      {option.hasThinking && (
-                        <Badge
-                          variant="outline"
-                          className={cn(
-                            'text-xs',
-                            isSelected
-                              ? 'border-primary-foreground/50 text-primary-foreground'
-                              : 'border-emerald-500/50 text-emerald-600 dark:text-emerald-400'
-                          )}
-                        >
-                          Thinking
-                        </Badge>
-                      )}
-                      {option.badge && (
-                        <Badge
-                          variant="outline"
-                          className={cn(
-                            'text-xs',
-                            isSelected
-                              ? 'border-primary-foreground/50 text-primary-foreground'
-                              : 'border-muted-foreground/50 text-muted-foreground'
-                          )}
-                        >
-                          {option.badge}
-                        </Badge>
-                      )}
-                    </div>
-                  </button>
-                );
-              })}
-            </div>
-          )}
+          <DynamicModelList
+            models={transformedCodexModels}
+            selectedModel={selectedModel}
+            onModelSelect={onModelSelect}
+            testIdPrefix={testIdPrefix}
+            isLoading={codexModelsLoading}
+            error={codexModelsError}
+            onRetry={() => fetchCodexModels(true)}
+            emptyMessage="No Codex models available"
+            badgeColorClass="border-muted-foreground/50 text-muted-foreground"
+            thinkingBadgeColorClass="border-emerald-500/50 text-emerald-600 dark:text-emerald-400"
+            showThinkingBadge
+          />
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary

This PR adds support for the OpenCode CLI provider in the `ModelSelector` component, enabling users to access GitHub Copilot models and other providers authenticated through the OpenCode CLI.

## Changes

### `apps/ui/src/components/views/board-view/shared/model-selector.tsx`

- Added OpenCode as a fourth provider option alongside Claude, Cursor CLI, and Codex CLI
- Implemented OpenCode model fetching from the store on component mount
- Added UI for displaying OpenCode models with proper loading, error, and empty states
- Models dynamically fetched via OpenCode CLI are displayed with tier badges (Free, Balanced, Premium)
- Added provider availability check for OpenCode CLI authentication status

## Features

- **Provider Selection**: Users can now select OpenCode CLI as their AI provider
- **Dynamic Model Discovery**: Models are automatically fetched from the OpenCode CLI, including GitHub Copilot models (claude-sonnet-4, gpt-5.2-codex, etc.)
- **Model Tiers**: Models are badged by tier (Free, Balanced, Premium) for easy identification
- **Error Handling**: Proper error states with retry functionality if model fetching fails
- **Loading States**: Shows loading spinner while models are being fetched
- **Authentication Warning**: Displays warning when OpenCode CLI is not installed or authenticated

## Testing

1. Ensure OpenCode CLI is installed (`npx opencode-ai@latest --version`)
2. Authenticate with a provider (e.g., `npx opencode-ai@latest auth login` and select GitHub Copilot)
3. Open the model selector in the feature creation dialog
4. Verify OpenCode CLI appears as a provider option
5. Select OpenCode CLI and verify models are loaded and displayed
6. Verify models can be selected and used for feature generation

## Screenshots
<img width="1881" height="1059" alt="image" src="https://github.com/user-attachments/assets/9d30d8f3-5b27-444c-954c-d60b959886ca" />

## Checklist

- [x] Code follows project style guidelines
- [x] Changes are consistent with existing CLI provider implementations
- [x] No breaking changes to existing functionality
