### PR TITLE
feat: ideation configurable model

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -284,7 +284,10 @@ app.use('/api/context', createContextRoutes(settingsService));
 app.use('/api/backlog-plan', createBacklogPlanRoutes(events, settingsService));
 app.use('/api/mcp', createMCPRoutes(mcpTestService));
 app.use('/api/pipeline', createPipelineRoutes(pipelineService));
-app.use('/api/ideation', createIdeationRoutes(events, ideationService, featureLoader));
+app.use(
+  '/api/ideation',
+  createIdeationRoutes(events, ideationService, featureLoader, settingsService)
+);
 
 // Create HTTP server
 const server = createServer(app);

--- a/apps/server/src/routes/ideation/index.ts
+++ b/apps/server/src/routes/ideation/index.ts
@@ -7,6 +7,7 @@ import type { EventEmitter } from '../../lib/events.js';
 import { validatePathParams } from '../../middleware/validate-paths.js';
 import type { IdeationService } from '../../services/ideation-service.js';
 import type { FeatureLoader } from '../../services/feature-loader.js';
+import type { SettingsService } from '../../services/settings-service.js';
 
 // Route handlers
 import { createSessionStartHandler } from './routes/session-start.js';
@@ -27,7 +28,8 @@ import { createSuggestionsGenerateHandler } from './routes/suggestions-generate.
 export function createIdeationRoutes(
   events: EventEmitter,
   ideationService: IdeationService,
-  featureLoader: FeatureLoader
+  featureLoader: FeatureLoader,
+  settingsService: SettingsService
 ): Router {
   const router = Router();
 
@@ -91,7 +93,7 @@ export function createIdeationRoutes(
   router.post(
     '/add-suggestion',
     validatePathParams('projectPath'),
-    createAddSuggestionHandler(ideationService, featureLoader)
+    createAddSuggestionHandler(ideationService, featureLoader, settingsService)
   );
 
   // Guided prompts (no validation needed - static data)

--- a/apps/server/src/routes/ideation/routes/add-suggestion.ts
+++ b/apps/server/src/routes/ideation/routes/add-suggestion.ts
@@ -4,17 +4,22 @@
  * This endpoint converts an AnalysisSuggestion to a Feature using the
  * IdeationService's mapIdeaCategoryToFeatureCategory for consistent category mapping.
  * This ensures a single source of truth for the conversion logic.
+ *
+ * The feature is created with the user's configured defaultFeatureModel from settings,
+ * ensuring consistency with manually created features.
  */
 
 import type { Request, Response } from 'express';
 import type { IdeationService } from '../../../services/ideation-service.js';
 import type { FeatureLoader } from '../../../services/feature-loader.js';
+import type { SettingsService } from '../../../services/settings-service.js';
 import type { AnalysisSuggestion } from '@automaker/types';
 import { getErrorMessage, logError } from '../common.js';
 
 export function createAddSuggestionHandler(
   ideationService: IdeationService,
-  featureLoader: FeatureLoader
+  featureLoader: FeatureLoader,
+  settingsService: SettingsService
 ) {
   return async (req: Request, res: Response): Promise<void> => {
     try {
@@ -53,12 +58,23 @@ export function createAddSuggestionHandler(
         suggestion.category
       );
 
-      // Create the feature
+      // Get the default feature model from user settings
+      let model: string | undefined;
+      try {
+        const settings = await settingsService.getGlobalSettings();
+        model = settings.defaultFeatureModel?.model;
+      } catch (error) {
+        // If settings fail to load, proceed without a model (will use system default)
+        logError(error, 'Failed to get default feature model from settings');
+      }
+
+      // Create the feature with the configured default model
       const feature = await featureLoader.create(projectPath, {
         title: suggestion.title,
         description,
         category: featureCategory,
         status: 'backlog',
+        ...(model && { model }), // Only include model if it was retrieved
       });
 
       res.json({ success: true, featureId: feature.id });

--- a/apps/server/src/services/ideation-service.ts
+++ b/apps/server/src/services/ideation-service.ts
@@ -208,7 +208,17 @@ export class IdeationService {
       );
 
       // Resolve model alias to canonical identifier (with prefix)
-      const modelId = resolveModelString(options?.model ?? 'sonnet');
+      let defaultModel = 'sonnet';
+      if (this.settingsService) {
+        try {
+          const settings = await this.settingsService.getGlobalSettings();
+          defaultModel = settings.phaseModels.ideationModel.model;
+        } catch (error) {
+          logger.warn('Failed to get settings for model selection, using default', error);
+        }
+      }
+
+      const modelId = resolveModelString(options?.model ?? defaultModel);
 
       // Create SDK options
       const sdkOptions = createChatOptions({
@@ -663,7 +673,17 @@ export class IdeationService {
       );
 
       // Resolve model alias to canonical identifier (with prefix)
-      const modelId = resolveModelString('sonnet');
+      let modelToUse = 'sonnet';
+      if (this.settingsService) {
+        try {
+          const settings = await this.settingsService.getGlobalSettings();
+          modelToUse = settings.phaseModels.suggestionsModel.model;
+        } catch (error) {
+          logger.warn('Failed to get settings for model selection, using default', error);
+        }
+      }
+
+      const modelId = resolveModelString(modelToUse);
 
       // Create SDK options
       const sdkOptions = createChatOptions({

--- a/apps/ui/src/components/views/settings-view/model-defaults/model-defaults-section.tsx
+++ b/apps/ui/src/components/views/settings-view/model-defaults/model-defaults-section.tsx
@@ -69,6 +69,11 @@ const GENERATION_TASKS: PhaseConfig[] = [
     label: 'AI Suggestions',
     description: 'Model for feature, refactoring, security, and performance suggestions',
   },
+  {
+    key: 'ideationModel',
+    label: 'Ideation & Brainstorming',
+    description: 'Interactive brainstorming and idea generation sessions',
+  },
 ];
 
 const MEMORY_TASKS: PhaseConfig[] = [

--- a/libs/types/src/settings.ts
+++ b/libs/types/src/settings.ts
@@ -247,6 +247,8 @@ export interface PhaseModelConfig {
   projectAnalysisModel: PhaseModelEntry;
   /** Model for AI suggestions (feature, refactoring, security, performance) */
   suggestionsModel: PhaseModelEntry;
+  /** Model for interactive ideation and brainstorming sessions */
+  ideationModel: PhaseModelEntry;
 
   // Memory tasks - for learning extraction and memory operations
   /** Model for extracting learnings from completed agent sessions */
@@ -777,6 +779,7 @@ export const DEFAULT_PHASE_MODELS: PhaseModelConfig = {
   backlogPlanningModel: { model: 'sonnet' },
   projectAnalysisModel: { model: 'sonnet' },
   suggestionsModel: { model: 'sonnet' },
+  ideationModel: { model: 'sonnet' },
 
   // Memory - use fast model for learning extraction (cost-effective)
   memoryExtractionModel: { model: 'haiku' },


### PR DESCRIPTION
## Summary

This PR adds a dedicated `ideationModel` setting to give users granular control over which AI model powers the Ideation pane, distinct from `suggestionsModel`. It also fixes an issue where tasks created from ideation suggestions were not inheriting the correct model configuration.

## Problem

Previously:
1. The Ideation pane used `suggestionsModel` for interactive brainstorming sessions, offering no separate configuration
2. When ideas from the Ideation pane were accepted and converted to tasks, they defaulted to hardcoded model values instead of respecting user settings

## Solution

### New `ideationModel` Setting
- Added `ideationModel` to the `PhaseModelConfig` interface in `libs/types/src/settings.ts`
- Added default value (`sonnet`) in `DEFAULT_PHASE_MODELS`
- Added UI entry "Ideation & Brainstorming" under Model Defaults > Generation Tasks
- Updated `ideation-service.ts` to use `ideationModel` for interactive chat sessions

### Task Model Defaults Fix
- Updated `add-suggestion.ts` to retrieve `defaultFeatureModel` from user settings
- Features created from ideation suggestions now use the user's configured model

## Files Changed

| File | Change |
|------|--------|
| `libs/types/src/settings.ts` | Added `ideationModel` to interface and defaults |
| `apps/ui/.../model-defaults-section.tsx` | Added UI entry for ideation model |
| `apps/server/.../ideation-service.ts` | Use `ideationModel` for chat sessions |
| `apps/server/.../add-suggestion.ts` | Apply `defaultFeatureModel` to created tasks |
| `apps/server/.../ideation/index.ts` | Pass `settingsService` to route handlers |

## Testing

- [x] TypeScript compilation passes (`npx tsc --noEmit`)
- [x] Package builds succeed (`npm run build:packages`)
- [ ] Manual UI verification (blocked by pre-existing dev server issue)

## Notes

The dev server has a pre-existing `CachedInputFileSystem` error unrelated to these changes, which blocks local UI testing. Code correctness has been verified through type checking and build validation.