### PR TITLE
docs: add hint about AUTOMAKER_API_KEY env var to API key banner

### DIFF
--- a/apps/server/src/lib/auth.ts
+++ b/apps/server/src/lib/auth.ts
@@ -142,6 +142,8 @@ if (process.env.AUTOMAKER_HIDE_API_KEY !== 'true') {
 ║    ${API_KEY}
 ║                                                                       ║
 ║  In Electron mode, authentication is handled automatically.          ║
+║                                                                       ║
+║  💡 Tip: Set AUTOMAKER_API_KEY env var to use a fixed key for dev    ║
 ╚═══════════════════════════════════════════════════════════════════════╝
 `);
 } else {


### PR DESCRIPTION
## Summary

When the dev server restarts (especially clean restarts), developers have to re-enter the API key in the browser. While the API key is persisted to `./data/.api-key`, this file may be missing or cleaned in some development scenarios.

This PR adds a helpful tip to the API key banner informing developers about the `AUTOMAKER_API_KEY` environment variable, which allows setting a fixed API key that persists across server restarts.

### Before
```
╔═══════════════════════════════════════════════════════════════════════╗
║  🔐 API Key for Web Mode Authentication                               ║
╠═══════════════════════════════════════════════════════════════════════╣
║                                                                       ║
║  When accessing via browser, you'll be prompted to enter this key:    ║
║                                                                       ║
║    00c4f38e-3547-4932-957b-97be182d3c00                               ║
║                                                                       ║
║  In Electron mode, authentication is handled automatically.          ║
╚═══════════════════════════════════════════════════════════════════════╝
```

### After
```
╔═══════════════════════════════════════════════════════════════════════╗
║  🔐 API Key for Web Mode Authentication                               ║
╠═══════════════════════════════════════════════════════════════════════╣
║                                                                       ║
║  When accessing via browser, you'll be prompted to enter this key:    ║
║                                                                       ║
║    00c4f38e-3547-4932-957b-97be182d3c00                               ║
║                                                                       ║
║  In Electron mode, authentication is handled automatically.          ║
║                                                                       ║
║  💡 Tip: Set AUTOMAKER_API_KEY env var to use a fixed key for dev    ║
╚═══════════════════════════════════════════════════════════════════════╝
```

## Changes

- Added a tip line to the API key banner in `apps/server/src/lib/auth.ts`

## Test plan

- [x] Run `npm run dev:web` and verify the new tip appears in the banner
- [x] Set `AUTOMAKER_API_KEY=test-key` and run again - verify it says "Using API key from environment variable" and uses the specified key