### PR TITLE
fix: use getTerminalFontFamily for dev server logs terminal font

### DIFF
--- a/apps/ui/src/components/views/board-view/worktree-panel/components/dev-server-logs-panel.tsx
+++ b/apps/ui/src/components/views/board-view/worktree-panel/components/dev-server-logs-panel.tsx
@@ -256,7 +256,6 @@ export function DevServerLogsPanel({
               ref={xtermRef}
               className="h-full"
               minHeight={280}
-              fontSize={13}
               autoScroll={autoScrollEnabled}
               onScrollAwayFromBottom={() => setAutoScrollEnabled(false)}
               onScrollToBottom={() => setAutoScrollEnabled(true)}


### PR DESCRIPTION
## Summary
- Fixed font rendering issue in the dev server logs panel
- `XtermLogViewer` was passing `DEFAULT_TERMINAL_FONT` (`'default'`) directly to xterm.js, which is a sentinel value for the dropdown selector, not a valid CSS font family
- Now uses `getTerminalFontFamily()` to convert the sentinel to the actual font stack: `"Menlo, Monaco, 'Courier New', monospace"`

## Test plan
- Open a project with a dev server running
- Open the dev server logs panel
- Verify the terminal text displays with the correct monospace font (Menlo/Monaco)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Terminal font initialization improved for greater configurability.

* **New Features**
  * Terminal now uses the configured font and updates the display automatically when the font setting changes.

* **Chores**
  * Project switcher test identifiers standardized for more consistent testing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->