### PR TITLE
fix: improve project-switcher data-testid for uniqueness and special chars

### DIFF
--- a/apps/ui/src/components/layout/project-switcher/components/project-switcher-item.tsx
+++ b/apps/ui/src/components/layout/project-switcher/components/project-switcher-item.tsx
@@ -37,10 +37,28 @@ export function ProjectSwitcherItem({
   const IconComponent = getIconComponent();
   const hasCustomIcon = !!project.customIconPath;
 
+  // Create a sanitized project name for test ID:
+  // - Convert to lowercase
+  // - Replace spaces with hyphens
+  // - Remove all non-alphanumeric characters except hyphens
+  // - Collapse multiple hyphens into single hyphen
+  // - Trim leading/trailing hyphens
+  const sanitizedName = project.name
+    .toLowerCase()
+    .replace(/\s+/g, '-')
+    .replace(/[^a-z0-9-]/g, '')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '');
+
+  // Combine project.id with sanitized name for uniqueness and readability
+  // Format: project-switcher-{id}-{sanitizedName}
+  const testId = `project-switcher-${project.id}-${sanitizedName}`;
+
   return (
     <button
       onClick={onClick}
       onContextMenu={onContextMenu}
+      data-testid={testId}
       className={cn(
         'group w-full aspect-square rounded-xl flex items-center justify-center relative overflow-hidden',
         'transition-all duration-200 ease-out',
@@ -60,7 +78,6 @@ export function ProjectSwitcherItem({
         'hover:scale-105 active:scale-95'
       )}
       title={project.name}
-      data-testid={`project-switcher-${project.id}`}
     >
       {hasCustomIcon ? (
         <img

--- a/apps/ui/tests/features/feature-manual-review-flow.spec.ts
+++ b/apps/ui/tests/features/feature-manual-review-flow.spec.ts
@@ -131,7 +131,8 @@ test.describe('Feature Manual Review Flow', () => {
     }
 
     // Verify we're on the correct project (project switcher button shows project name)
-    await expect(page.getByTestId(`project-switcher-project-${projectName}`)).toBeVisible({
+    // Use ends-with selector since data-testid format is: project-switcher-{id}-{sanitizedName}
+    await expect(page.locator(`[data-testid$="-${projectName}"]`)).toBeVisible({
       timeout: 10000,
     });
 

--- a/apps/ui/tests/projects/new-project-creation.spec.ts
+++ b/apps/ui/tests/projects/new-project-creation.spec.ts
@@ -78,7 +78,8 @@ test.describe('Project Creation', () => {
 
     // Wait for project to be set as current and visible on the page
     // The project name appears in the project switcher button
-    await expect(page.getByTestId(`project-switcher-project-${projectName}`)).toBeVisible({
+    // Use ends-with selector since data-testid format is: project-switcher-{id}-{sanitizedName}
+    await expect(page.locator(`[data-testid$="-${projectName}"]`)).toBeVisible({
       timeout: 15000,
     });
 

--- a/apps/ui/tests/projects/open-existing-project.spec.ts
+++ b/apps/ui/tests/projects/open-existing-project.spec.ts
@@ -157,8 +157,9 @@ test.describe('Open Project', () => {
 
     // Wait for a project to be set as current and visible on the page
     // The project name appears in the project switcher button
+    // Use ends-with selector since data-testid format is: project-switcher-{id}-{sanitizedName}
     if (targetProjectName) {
-      await expect(page.getByTestId(`project-switcher-project-${targetProjectName}`)).toBeVisible({
+      await expect(page.locator(`[data-testid$="-${targetProjectName}"]`)).toBeVisible({
         timeout: 15000,
       });
     }


### PR DESCRIPTION
## Summary
- Combines stable `project.id` with sanitized name for unique, deterministic test IDs
- Expands sanitization to properly handle special characters (removes non-alphanumeric except hyphens)
- Updates E2E tests to use ends-with selector pattern for matching

This addresses the CodeRabbitAI feedback on PR #574 regarding potential test-id collisions and special character handling.

## Test plan
- [ ] E2E tests pass with the new data-testid format
- [ ] Project switcher items can be selected by tests using the ends-with pattern
- [ ] Projects with special characters in names produce valid CSS selectors