### PR TITLE
Fix undefined values breaking the feature card display

### DIFF
--- a/apps/ui/src/components/ui/autocomplete.tsx
+++ b/apps/ui/src/components/ui/autocomplete.tsx
@@ -65,7 +65,14 @@ export function Autocomplete({
   const [triggerWidth, setTriggerWidth] = React.useState<number>(0);
   const triggerRef = React.useRef<HTMLButtonElement>(null);
 
-  const normalizedOptions = React.useMemo(() => options.map(normalizeOption), [options]);
+  const normalizedOptions = React.useMemo(
+    () =>
+      options
+        .filter((opt) => opt != null)
+        .map(normalizeOption)
+        .filter((opt) => opt.value != null),
+    [options]
+  );
 
   // Update trigger width when component mounts or value changes
   React.useEffect(() => {


### PR DESCRIPTION
Before:
<img width="1719" height="996" alt="image" src="https://github.com/user-attachments/assets/b9f65d4a-229f-4dbf-a2a9-46de3e99b4bb" />

After:

<img width="1602" height="941" alt="image" src="https://github.com/user-attachments/assets/849e40f6-cfdf-4095-a9f8-5e9d982fd821" />

Safely checks for undefined values that were previously breaking the feature card display. 

I believe I got this error in the first place because I started a new project in AutoMaker from an existing repo URL. I had the agent with an AutoMaker view open issues and PRs for the project that I was cloning. The agent then added new tasks into the kanban board itself, and I'm guessing did it incorrectly. It made adding a new feature impossible though, and this fixes that. 

All tests pass. This is my first contribution to this project, I hope I did everything all right, and I hope to contribute a lot more as I get faster at this. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved autocomplete functionality to properly filter out null entries and empty values from dropdown options, ensuring cleaner and more reliable option rendering.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->