### PR TITLE
fix: Hide worktree branches from branch switcher and show worktree tabs

### DIFF
--- a/apps/server/src/routes/worktree/routes/list-branches.ts
+++ b/apps/server/src/routes/worktree/routes/list-branches.ts
@@ -16,6 +16,37 @@ interface BranchInfo {
   name: string;
   isCurrent: boolean;
   isRemote: boolean;
+  /** Path to worktree if this branch is checked out in a worktree (null if not) */
+  checkedOutInWorktree: string | null;
+}
+
+/**
+ * Get a map of branch names to their worktree paths.
+ * Git doesn't allow checking out a branch that's already checked out in a worktree.
+ */
+async function getWorktreeBranches(cwd: string): Promise<Map<string, string>> {
+  const branchToWorktree = new Map<string, string>();
+  try {
+    const { stdout } = await execAsync('git worktree list --porcelain', { cwd });
+    const lines = stdout.split('\n');
+    let currentWorktreePath: string | null = null;
+
+    for (const line of lines) {
+      if (line.startsWith('worktree ')) {
+        currentWorktreePath = line.slice(9);
+      } else if (line.startsWith('branch ')) {
+        const branchName = line.slice(7).replace('refs/heads/', '');
+        if (currentWorktreePath) {
+          branchToWorktree.set(branchName, currentWorktreePath);
+        }
+      } else if (line === '') {
+        currentWorktreePath = null;
+      }
+    }
+  } catch {
+    // If we can't get worktree info, return empty map
+  }
+  return branchToWorktree;
 }
 
 export function createListBranchesHandler() {
@@ -40,6 +71,10 @@ export function createListBranchesHandler() {
       });
       const currentBranch = currentBranchOutput.trim();
 
+      // Get branches that are already checked out in worktrees
+      // These cannot be switched to from other locations
+      const worktreeBranches = await getWorktreeBranches(worktreePath);
+
       // List all local branches
       // Use double quotes around the format string for cross-platform compatibility
       // Single quotes are preserved literally on Windows; double quotes work on both
@@ -54,10 +89,13 @@ export function createListBranchesHandler() {
         .map((name) => {
           // Remove any surrounding quotes (Windows git may preserve them)
           const cleanName = name.trim().replace(/^['"]|['"]$/g, '');
+          const worktreePath = worktreeBranches.get(cleanName);
           return {
             name: cleanName,
             isCurrent: cleanName === currentBranch,
             isRemote: false,
+            // Mark if this branch is checked out in a worktree (and it's not the current worktree)
+            checkedOutInWorktree: worktreePath && cleanName !== currentBranch ? worktreePath : null,
           };
         });
 
@@ -102,6 +140,7 @@ export function createListBranchesHandler() {
                   name: cleanName, // Keep full name like "origin/main"
                   isCurrent: false,
                   isRemote: true,
+                  checkedOutInWorktree: null, // Remote branches are never checked out in worktrees
                 });
               }
             });

--- a/apps/ui/src/components/layout/sidebar/hooks/use-project-creation.ts
+++ b/apps/ui/src/components/layout/sidebar/hooks/use-project-creation.ts
@@ -12,9 +12,7 @@ interface UseProjectCreationProps {
   upsertAndSetCurrentProject: (path: string, name: string) => Project;
 }
 
-export function useProjectCreation({
-  upsertAndSetCurrentProject,
-}: UseProjectCreationProps) {
+export function useProjectCreation({ upsertAndSetCurrentProject }: UseProjectCreationProps) {
   // Modal state
   const [showNewProjectModal, setShowNewProjectModal] = useState(false);
   const [isCreatingProject, setIsCreatingProject] = useState(false);

--- a/apps/ui/src/components/views/board-view/worktree-panel/components/branch-switch-dropdown.tsx
+++ b/apps/ui/src/components/views/board-view/worktree-panel/components/branch-switch-dropdown.tsx
@@ -90,21 +90,23 @@ export function BranchSwitchDropdown({
               {branchFilter ? 'No matching branches' : 'No branches found'}
             </DropdownMenuItem>
           ) : (
-            filteredBranches.map((branch) => (
-              <DropdownMenuItem
-                key={branch.name}
-                onClick={() => onSwitchBranch(worktree, branch.name)}
-                disabled={isSwitching || branch.name === worktree.branch}
-                className="text-xs font-mono"
-              >
-                {branch.name === worktree.branch ? (
-                  <Check className="w-3.5 h-3.5 mr-2 flex-shrink-0" />
-                ) : (
-                  <span className="w-3.5 mr-2 flex-shrink-0" />
-                )}
-                <span className="truncate">{branch.name}</span>
-              </DropdownMenuItem>
-            ))
+            filteredBranches
+              .filter((branch) => !branch.checkedOutInWorktree) // Hide branches already in worktrees
+              .map((branch) => (
+                <DropdownMenuItem
+                  key={branch.name}
+                  onClick={() => onSwitchBranch(worktree, branch.name)}
+                  disabled={isSwitching || branch.name === worktree.branch}
+                  className="text-xs font-mono"
+                >
+                  {branch.name === worktree.branch ? (
+                    <Check className="w-3.5 h-3.5 mr-2 flex-shrink-0" />
+                  ) : (
+                    <span className="w-3.5 mr-2 flex-shrink-0" />
+                  )}
+                  <span className="truncate">{branch.name}</span>
+                </DropdownMenuItem>
+              ))
           )}
         </div>
         <DropdownMenuSeparator />

--- a/apps/ui/src/components/views/board-view/worktree-panel/types.ts
+++ b/apps/ui/src/components/views/board-view/worktree-panel/types.ts
@@ -17,6 +17,8 @@ export interface BranchInfo {
   name: string;
   isCurrent: boolean;
   isRemote: boolean;
+  /** Path to worktree if this branch is checked out in a worktree (null if not) */
+  checkedOutInWorktree: string | null;
 }
 
 export interface GitRepoStatus {

--- a/apps/ui/src/components/views/board-view/worktree-panel/worktree-panel.tsx
+++ b/apps/ui/src/components/views/board-view/worktree-panel/worktree-panel.tsx
@@ -355,8 +355,8 @@ export function WorktreePanel({
         )}
       </div>
 
-      {/* Worktrees section - only show if enabled */}
-      {useWorktreesEnabled && (
+      {/* Worktrees section - show if enabled OR if worktrees exist (so users can navigate to them) */}
+      {(useWorktreesEnabled || nonMainWorktrees.length > 0) && (
         <>
           <div className="w-px h-5 bg-border mx-2" />
           <GitBranch className="w-4 h-4 text-muted-foreground" />


### PR DESCRIPTION
## Summary

- Branches already checked out in worktrees are now hidden from the branch switch dropdown (since git doesn't allow checking out a branch that's in another worktree)
- Worktree tabs now appear when worktrees exist, even if the "Use Worktrees" setting is disabled, so users can navigate to their existing worktrees

## Problem

When users had worktrees but didn't have the "Use Worktrees" setting enabled:
1. The branch dropdown showed branches marked with worktree info
2. Clicking them failed with "git checkout failed: branch already checked out"
3. The worktree tabs weren't visible, so users had no way to navigate to their worktrees

## Test plan

- [x] Build passes
- [x] All tests pass
- [x] Manually verify branches in worktrees are hidden from dropdown
- [x] Manually verify worktree tabs appear when worktrees exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Branches checked out in other worktrees are now excluded from branch switching, preventing conflicts.
  * Worktrees section visibility now adapts based on actual worktree presence in the repository.

* **Style**
  * Minor code formatting adjustments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->