### PR TITLE
feat: Use feature title for auto-generated worktree branch names

### DIFF
--- a/apps/ui/src/components/views/board-view/hooks/use-board-actions.ts
+++ b/apps/ui/src/components/views/board-view/hooks/use-board-actions.ts
@@ -154,11 +154,12 @@ export function useBoardActions({
       } else if (workMode === 'auto') {
         // Auto-generate a branch name based on feature title and timestamp
         // Create a slug from the title: lowercase, replace non-alphanumeric with hyphens
-        const titleSlug = titleForBranch
-          .toLowerCase()
-          .replace(/[^a-z0-9]+/g, '-') // Replace non-alphanumeric sequences with hyphens
-          .substring(0, 50) // Limit length to keep branch names reasonable
-          .replace(/^-|-$/g, ''); // Remove leading/trailing hyphens
+        const titleSlug =
+          titleForBranch
+            .toLowerCase()
+            .replace(/[^a-z0-9]+/g, '-') // Replace non-alphanumeric sequences with hyphens
+            .replace(/^-|-$/g, '') // Remove leading/trailing hyphens
+            .substring(0, 50) || 'untitled'; // Fallback if slug is empty (e.g., title was only special chars)
         const timestamp = Date.now();
         finalBranchName = `feature/${titleSlug}-${timestamp}`;
       } else {
@@ -275,7 +276,6 @@ export function useBoardActions({
       currentProject,
       onWorktreeCreated,
       onWorktreeAutoSelect,
-      getPrimaryWorktreeBranch,
       features,
     ]
   );
@@ -339,11 +339,12 @@ export function useBoardActions({
       } else if (workMode === 'auto') {
         // Auto-generate a branch name based on feature title and timestamp
         // Create a slug from the title: lowercase, replace non-alphanumeric with hyphens
-        const titleSlug = titleForBranch
-          .toLowerCase()
-          .replace(/[^a-z0-9]+/g, '-') // Replace non-alphanumeric sequences with hyphens
-          .replace(/^-|-$/g, '') // Remove leading/trailing hyphens
-          .substring(0, 50); // Limit length to keep branch names reasonable
+        const titleSlug =
+          titleForBranch
+            .toLowerCase()
+            .replace(/[^a-z0-9]+/g, '-') // Replace non-alphanumeric sequences with hyphens
+            .replace(/^-|-$/g, '') // Remove leading/trailing hyphens
+            .substring(0, 50) || 'untitled'; // Fallback if slug is empty (e.g., title was only special chars)
         const timestamp = Date.now();
         finalBranchName = `feature/${titleSlug}-${timestamp}`;
       } else {
@@ -450,7 +451,6 @@ export function useBoardActions({
       setEditingFeature,
       currentProject,
       onWorktreeCreated,
-      getPrimaryWorktreeBranch,
       features,
     ]
   );


### PR DESCRIPTION
## Summary

Auto-generated worktree branches now use the feature title instead of generic timestamp-based names.

**Before:** `feature/main-1768848108952-j7ra`
**After:** `feature/add-user-authentication-1768848108952`

## Benefits

This makes it easier to identify which features are in which worktrees:
- Within Automaker's worktree panel and tabs
- In the terminal and IDE
- In git logs and branch listings

## Implementation

- When no title is provided (common case where users enter description only):
  - AI generates a title from the description BEFORE creating the worktree
  - The generated title is used for both the branch name and feature title
  - Falls back to first 60 chars of description if title generation fails
- Slugify feature title (lowercase, replace special chars with hyphens)
- Limit slug to 50 chars to keep branch names reasonable
- Keep timestamp suffix for uniqueness
- Updated both `handleAddFeature` and `handleUpdateFeature`

## Pre-submission Checklist

- [x] Targets the current RC branch (`v0.13.0rc`)
- [x] All tests pass (`npm run test:all` - 1718 passed)
- [x] Build passes (`npm run build`)
- [x] Manually tested:
  - [x] Create a feature with title + Auto Worktree mode → branch uses title
  - [x] Create a feature with description only (no title) + Auto Worktree mode → AI generates title, branch uses generated title

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Auto-generates feature titles from descriptions during create/update and applies them when available.
  * Uses generated or derived titles for automatic branch naming.

* **Improvements**
  * Branch names now use a slugified title plus timestamp for clearer, consistent names.
  * Removes reliance on a primary base branch for auto-naming.
  * Avoids duplicate title generation and preserves improved fallbacks when generation or branch creation fail.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->