### PR TITLE
fix: convert OpenCode model format to CLI slash format

### DIFF
--- a/apps/server/src/providers/opencode-provider.ts
+++ b/apps/server/src/providers/opencode-provider.ts
@@ -330,28 +330,13 @@ export class OpencodeProvider extends CliProvider {
     // Convert canonical prefix format (opencode-xxx) to CLI slash format (opencode/xxx)
     // OpenCode CLI expects provider/model format (e.g., 'opencode/big-model')
     if (options.model) {
-      let cliModel: string;
+      // Strip opencode- prefix if present, then ensure slash format
+      const model = options.model.startsWith('opencode-')
+        ? options.model.slice('opencode-'.length)
+        : options.model;
 
-      if (options.model.startsWith('opencode-')) {
-        // Strip the opencode- prefix
-        const remainder = options.model.slice('opencode-'.length);
-
-        if (remainder.includes('/')) {
-          // Remainder already has provider/model format (e.g., opencode-anthropic/claude-sonnet-4-5)
-          // Use as-is without the opencode- prefix
-          cliModel = remainder;
-        } else {
-          // Bare model name after stripping prefix (e.g., opencode-big-model)
-          // Convert to opencode/model format for CLI
-          cliModel = `opencode/${remainder}`;
-        }
-      } else if (options.model.includes('/')) {
-        // Already in provider/model format (e.g., github-copilot/gpt-4o)
-        cliModel = options.model;
-      } else {
-        // Bare model name - assume opencode provider
-        cliModel = `opencode/${options.model}`;
-      }
+      // If model has slash, it's already provider/model format; otherwise prepend opencode/
+      const cliModel = model.includes('/') ? model : `opencode/${model}`;
 
       args.push('--model', cliModel);
     }


### PR DESCRIPTION
## Summary

Fixes OpenCode CLI model format conversion that was broken after commit `4b0d1399` changed model IDs from slash format (`opencode/model`) to prefix format (`opencode-model`).

## Problem

After selecting an OpenCode model (e.g., "Big Pickle"), the CLI would fail with:

```
ProviderModelNotFoundError
  providerID: "big-pickle"
  modelID: ""
```

The CLI was receiving `--model big-pickle` instead of `--model opencode/big-pickle`.

## Root Cause

1. Commit `4b0d1399` ("feat: implement cursor model migration and enhance auto mode functionality") changed OpenCode model IDs from `opencode/big-pickle` to `opencode-big-pickle`
2. The `buildCliArgs()` method in `opencode-provider.ts` was **not updated** to convert the new format back to CLI format
3. `simple-query-service.ts` calls `stripProviderPrefix()` which strips `opencode-` prefix
4. Result: bare model name `big-pickle` was passed to CLI, which interpreted it as a provider ID

## Solution

Updated `buildCliArgs()` to properly convert model formats:

| Input (after prefix strip) | CLI Argument | Reason |
|---------------------------|--------------|--------|
| `big-pickle` | `opencode/big-pickle` | Bare name → prepend `opencode/` |
| `glm-4.7-free` | `opencode/glm-4.7-free` | Bare name → prepend `opencode/` |
| `github-copilot/gpt-4o` | `github-copilot/gpt-4o` | Has slash → pass through |
| `google/gemini-2.5-pro` | `google/gemini-2.5-pro` | Has slash → pass through |

This handles all 100+ dynamic provider models correctly - the slash detection ensures dynamic models pass through unchanged.

## Testing

- [x] Server unit tests pass (`npm run test:server`)
- [x] Manual test: Select OpenCode model, run feature, verify no error

## Files Changed

- `apps/server/src/providers/opencode-provider.ts` - Updated `buildCliArgs()` method

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model name handling so different model naming formats and prefixes (including provider-qualified names) are consistently translated for CLI use, preventing mismatches when specifying models.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->