### PR TITLE
feat: Add configurable dev server port for project settings

### DIFF
--- a/apps/ui/src/components/views/board-view/worktree-panel/components/worktree-actions-dropdown.tsx
+++ b/apps/ui/src/components/views/board-view/worktree-panel/components/worktree-actions-dropdown.tsx
@@ -54,6 +54,8 @@ interface WorktreeActionsDropdownProps {
   isDevServerRunning: boolean;
   devServerInfo?: DevServerInfo;
   gitRepoStatus: GitRepoStatus;
+  /** Project path for looking up project-specific settings like devServerPort */
+  projectPath: string;
   /** When true, renders as a standalone button (not attached to another element) */
   standalone?: boolean;
   onOpenChange: (open: boolean) => void;
@@ -87,6 +89,7 @@ export function WorktreeActionsDropdown({
   isDevServerRunning,
   devServerInfo,
   gitRepoStatus,
+  projectPath,
   standalone = false,
   onOpenChange,
   onPull,
@@ -109,6 +112,11 @@ export function WorktreeActionsDropdown({
 }: WorktreeActionsDropdownProps) {
   // Get available editors for the "Open In" submenu
   const { editors } = useAvailableEditors();
+
+  // Get configured dev server port (project-specific override)
+  const getDevServerPort = useAppStore((s) => s.getDevServerPort);
+  const configuredPort = getDevServerPort(projectPath);
+  const effectivePort = configuredPort ?? devServerInfo?.port;
 
   // Use shared hook for effective default editor
   const effectiveDefaultEditor = useEffectiveDefaultEditor(editors);
@@ -178,12 +186,12 @@ export function WorktreeActionsDropdown({
           <>
             <DropdownMenuLabel className="text-xs flex items-center gap-2">
               <span className="w-2 h-2 rounded-full bg-green-500 animate-pulse" />
-              Dev Server Running (:{devServerInfo?.port})
+              Dev Server Running (:{effectivePort})
             </DropdownMenuLabel>
             <DropdownMenuItem
               onClick={() => onOpenDevServerUrl(worktree)}
               className="text-xs"
-              aria-label={`Open dev server on port ${devServerInfo?.port} in browser`}
+              aria-label={`Open dev server on port ${effectivePort} in browser`}
             >
               <Globe className="w-3.5 h-3.5 mr-2" aria-hidden="true" />
               Open in Browser

--- a/apps/ui/src/components/views/board-view/worktree-panel/components/worktree-tab.tsx
+++ b/apps/ui/src/components/views/board-view/worktree-panel/components/worktree-tab.tsx
@@ -4,6 +4,7 @@ import { Globe, CircleDot, GitPullRequest } from 'lucide-react';
 import { Spinner } from '@/components/ui/spinner';
 import { cn } from '@/lib/utils';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
+import { useAppStore } from '@/store/app-store';
 import type { WorktreeInfo, BranchInfo, DevServerInfo, PRInfo, GitRepoStatus } from '../types';
 import { BranchSwitchDropdown } from './branch-switch-dropdown';
 import { WorktreeActionsDropdown } from './worktree-actions-dropdown';
@@ -29,6 +30,8 @@ interface WorktreeTabProps {
   aheadCount: number;
   behindCount: number;
   gitRepoStatus: GitRepoStatus;
+  /** Project path for looking up project-specific settings */
+  projectPath: string;
   onSelectWorktree: (worktree: WorktreeInfo) => void;
   onBranchDropdownOpenChange: (open: boolean) => void;
   onActionsDropdownOpenChange: (open: boolean) => void;
@@ -75,6 +78,7 @@ export function WorktreeTab({
   aheadCount,
   behindCount,
   gitRepoStatus,
+  projectPath,
   onSelectWorktree,
   onBranchDropdownOpenChange,
   onActionsDropdownOpenChange,
@@ -99,6 +103,11 @@ export function WorktreeTab({
   onRunInitScript,
   hasInitScript,
 }: WorktreeTabProps) {
+  // Get configured dev server port (project-specific override)
+  const getDevServerPort = useAppStore((s) => s.getDevServerPort);
+  const configuredPort = getDevServerPort(projectPath);
+  const effectivePort = configuredPort ?? devServerInfo?.port;
+
   let prBadge: JSX.Element | null = null;
   if (worktree.pr) {
     const prState = worktree.pr.state?.toLowerCase() ?? 'open';
@@ -320,13 +329,13 @@ export function WorktreeTab({
                   'text-green-500'
                 )}
                 onClick={() => onOpenDevServerUrl(worktree)}
-                aria-label={`Open dev server on port ${devServerInfo?.port} in browser`}
+                aria-label={`Open dev server on port ${effectivePort} in browser`}
               >
                 <Globe className="w-3 h-3" aria-hidden="true" />
               </Button>
             </TooltipTrigger>
             <TooltipContent>
-              <p>Open dev server (:{devServerInfo?.port})</p>
+              <p>Open dev server (:{effectivePort})</p>
             </TooltipContent>
           </Tooltip>
         </TooltipProvider>
@@ -343,6 +352,7 @@ export function WorktreeTab({
         isDevServerRunning={isDevServerRunning}
         devServerInfo={devServerInfo}
         gitRepoStatus={gitRepoStatus}
+        projectPath={projectPath}
         onOpenChange={onActionsDropdownOpenChange}
         onPull={onPull}
         onPush={onPush}

--- a/apps/ui/src/components/views/board-view/worktree-panel/hooks/use-dev-servers.ts
+++ b/apps/ui/src/components/views/board-view/worktree-panel/hooks/use-dev-servers.ts
@@ -3,6 +3,7 @@ import { createLogger } from '@automaker/utils/logger';
 import { getElectronAPI } from '@/lib/electron';
 import { normalizePath } from '@/lib/utils';
 import { toast } from 'sonner';
+import { useAppStore } from '@/store/app-store';
 import type { DevServerInfo, WorktreeInfo } from '../types';
 
 const logger = createLogger('DevServers');
@@ -14,6 +15,10 @@ interface UseDevServersOptions {
 export function useDevServers({ projectPath }: UseDevServersOptions) {
   const [isStartingDevServer, setIsStartingDevServer] = useState(false);
   const [runningDevServers, setRunningDevServers] = useState<Map<string, DevServerInfo>>(new Map());
+
+  // Get configured dev server port (project-specific override)
+  const getDevServerPort = useAppStore((s) => s.getDevServerPort);
+  const configuredPort = getDevServerPort(projectPath);
 
   const fetchDevServers = useCallback(async () => {
     try {
@@ -71,7 +76,9 @@ export function useDevServers({ projectPath }: UseDevServersOptions) {
             });
             return next;
           });
-          toast.success(`Dev server started on port ${result.result.port}`);
+          // Use configured port in toast message if set, otherwise use server-allocated port
+          const effectivePort = configuredPort ?? result.result.port;
+          toast.success(`Dev server started on port ${effectivePort}`);
         } else {
           toast.error(result.error || 'Failed to start dev server');
         }
@@ -143,6 +150,12 @@ export function useDevServers({ projectPath }: UseDevServersOptions) {
         }
 
         devServerUrl.hostname = window.location.hostname;
+
+        // Use configured port if set, otherwise use server-reported port
+        if (configuredPort) {
+          devServerUrl.port = String(configuredPort);
+        }
+
         window.open(devServerUrl.toString(), '_blank', 'noopener,noreferrer');
       } catch (error) {
         logger.error('Failed to parse dev server URL:', error);
@@ -151,7 +164,7 @@ export function useDevServers({ projectPath }: UseDevServersOptions) {
         });
       }
     },
-    [runningDevServers, getWorktreeKey]
+    [runningDevServers, getWorktreeKey, configuredPort]
   );
 
   const isDevServerRunning = useCallback(

--- a/apps/ui/src/components/views/board-view/worktree-panel/worktree-panel.tsx
+++ b/apps/ui/src/components/views/board-view/worktree-panel/worktree-panel.tsx
@@ -244,6 +244,7 @@ export function WorktreePanel({
             isDevServerRunning={isDevServerRunning(selectedWorktree)}
             devServerInfo={getDevServerInfo(selectedWorktree)}
             gitRepoStatus={gitRepoStatus}
+            projectPath={projectPath}
             onOpenChange={handleActionsDropdownOpenChange(selectedWorktree)}
             onPull={handlePull}
             onPush={handlePush}
@@ -328,6 +329,7 @@ export function WorktreePanel({
             aheadCount={aheadCount}
             behindCount={behindCount}
             gitRepoStatus={gitRepoStatus}
+            projectPath={projectPath}
             onSelectWorktree={handleSelectWorktree}
             onBranchDropdownOpenChange={handleBranchDropdownOpenChange(mainWorktree)}
             onActionsDropdownOpenChange={handleActionsDropdownOpenChange(mainWorktree)}
@@ -388,6 +390,7 @@ export function WorktreePanel({
                   aheadCount={aheadCount}
                   behindCount={behindCount}
                   gitRepoStatus={gitRepoStatus}
+                  projectPath={projectPath}
                   onSelectWorktree={handleSelectWorktree}
                   onBranchDropdownOpenChange={handleBranchDropdownOpenChange(worktree)}
                   onActionsDropdownOpenChange={handleActionsDropdownOpenChange(worktree)}

--- a/apps/ui/src/components/views/project-settings-view/worktree-preferences-section.tsx
+++ b/apps/ui/src/components/views/project-settings-view/worktree-preferences-section.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import { Label } from '@/components/ui/label';
+import { Input } from '@/components/ui/input';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Button } from '@/components/ui/button';
 import { ShellSyntaxEditor } from '@/components/ui/shell-syntax-editor';
@@ -11,6 +12,7 @@ import {
   RotateCcw,
   Trash2,
   PanelBottomClose,
+  Globe,
 } from 'lucide-react';
 import { Spinner } from '@/components/ui/spinner';
 import { cn } from '@/lib/utils';
@@ -42,6 +44,8 @@ export function WorktreePreferencesSection({ project }: WorktreePreferencesSecti
   const setDefaultDeleteBranch = useAppStore((s) => s.setDefaultDeleteBranch);
   const getAutoDismissInitScriptIndicator = useAppStore((s) => s.getAutoDismissInitScriptIndicator);
   const setAutoDismissInitScriptIndicator = useAppStore((s) => s.setAutoDismissInitScriptIndicator);
+  const getDevServerPort = useAppStore((s) => s.getDevServerPort);
+  const setDevServerPort = useAppStore((s) => s.setDevServerPort);
 
   // Get effective worktrees setting (project override or global fallback)
   const projectUseWorktrees = getProjectUseWorktrees(project.path);
@@ -58,6 +62,7 @@ export function WorktreePreferencesSection({ project }: WorktreePreferencesSecti
   const showIndicator = getShowInitScriptIndicator(project.path);
   const defaultDeleteBranch = getDefaultDeleteBranch(project.path);
   const autoDismiss = getAutoDismissInitScriptIndicator(project.path);
+  const devServerPort = getDevServerPort(project.path);
 
   // Check if there are unsaved changes
   const hasChanges = scriptContent !== originalContent;
@@ -93,6 +98,9 @@ export function WorktreePreferencesSection({ project }: WorktreePreferencesSecti
               response.settings.autoDismissInitScriptIndicator
             );
           }
+          if (response.settings.devServerPort !== undefined) {
+            setDevServerPort(currentPath, response.settings.devServerPort);
+          }
         }
       } catch (error) {
         if (!isCancelled) {
@@ -112,6 +120,7 @@ export function WorktreePreferencesSection({ project }: WorktreePreferencesSecti
     setShowInitScriptIndicator,
     setDefaultDeleteBranch,
     setAutoDismissInitScriptIndicator,
+    setDevServerPort,
   ]);
 
   // Load init script content when project changes
@@ -381,6 +390,72 @@ export function WorktreePreferencesSection({ project }: WorktreePreferencesSecti
             <p className="text-xs text-muted-foreground/80 leading-relaxed">
               When deleting a worktree, automatically check the "Also delete the branch" option.
             </p>
+          </div>
+        </div>
+
+        {/* Separator */}
+        <div className="border-t border-border/30" />
+
+        {/* Dev Server Port */}
+        <div className="group flex items-start space-x-3 p-3 rounded-xl hover:bg-accent/30 transition-colors duration-200 -mx-3">
+          <div className="w-5 h-5 mt-0.5 flex items-center justify-center">
+            <Globe className="w-4 h-4 text-brand-500" />
+          </div>
+          <div className="space-y-2 flex-1">
+            <Label
+              htmlFor="dev-server-port"
+              className="text-foreground font-medium flex items-center gap-2"
+            >
+              Dev Server Port
+            </Label>
+            <p className="text-xs text-muted-foreground/80 leading-relaxed">
+              Override the port displayed for the dev server. Use this when your framework (e.g.,
+              Vite, Next.js) ignores the allocated port and uses its own default.
+            </p>
+            <div className="flex items-center gap-2 pt-1">
+              <Input
+                id="dev-server-port"
+                type="number"
+                min={1}
+                max={65535}
+                placeholder="e.g., 5173"
+                value={devServerPort ?? ''}
+                onChange={async (e) => {
+                  const value = e.target.value ? parseInt(e.target.value, 10) : undefined;
+                  setDevServerPort(project.path, value);
+                  // Persist to server
+                  try {
+                    const httpClient = getHttpApiClient();
+                    await httpClient.settings.updateProject(project.path, {
+                      devServerPort: value,
+                    });
+                  } catch (error) {
+                    console.error('Failed to persist devServerPort:', error);
+                  }
+                }}
+                className="w-32 h-8 text-sm"
+              />
+              {devServerPort && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-8 text-xs text-muted-foreground"
+                  onClick={async () => {
+                    setDevServerPort(project.path, undefined);
+                    try {
+                      const httpClient = getHttpApiClient();
+                      await httpClient.settings.updateProject(project.path, {
+                        devServerPort: undefined,
+                      });
+                    } catch (error) {
+                      console.error('Failed to clear devServerPort:', error);
+                    }
+                  }}
+                >
+                  Clear
+                </Button>
+              )}
+            </div>
           </div>
         </div>
 

--- a/apps/ui/src/lib/http-api-client.ts
+++ b/apps/ui/src/lib/http-api-client.ts
@@ -2230,6 +2230,7 @@ export class HttpApiClient implements ElectronAPI {
         defaultDeleteBranchWithWorktree?: boolean;
         autoDismissInitScriptIndicator?: boolean;
         lastSelectedSessionId?: string;
+        devServerPort?: number;
       };
       error?: string;
     }> => this.post('/api/settings/project', { projectPath }),

--- a/apps/ui/src/store/app-store.ts
+++ b/apps/ui/src/store/app-store.ts
@@ -841,6 +841,10 @@ export interface AppState {
   // undefined = use global setting, true/false = project-specific override
   useWorktreesByProject: Record<string, boolean | undefined>;
 
+  // Dev Server Port Override (per-project, keyed by project path)
+  // Custom port to display for dev server (for projects where Vite/Next ignores PORT env var)
+  devServerPortByProject: Record<string, number | undefined>;
+
   // UI State (previously in localStorage, now synced via API)
   /** Whether worktree panel is collapsed in board view */
   worktreePanelCollapsed: boolean;
@@ -1315,6 +1319,10 @@ export interface AppActions {
   getProjectUseWorktrees: (projectPath: string) => boolean | undefined; // undefined = using global
   getEffectiveUseWorktrees: (projectPath: string) => boolean; // Returns actual value (project or global fallback)
 
+  // Dev Server Port Override actions (per-project)
+  setDevServerPort: (projectPath: string, port: number | undefined) => void;
+  getDevServerPort: (projectPath: string) => number | undefined;
+
   // UI State actions (previously in localStorage, now synced via API)
   setWorktreePanelCollapsed: (collapsed: boolean) => void;
   setLastProjectDir: (dir: string) => void;
@@ -1481,6 +1489,7 @@ const initialState: AppState = {
   defaultDeleteBranchByProject: {},
   autoDismissInitScriptIndicatorByProject: {},
   useWorktreesByProject: {},
+  devServerPortByProject: {},
   // UI State (previously in localStorage, now synced via API)
   worktreePanelCollapsed: false,
   lastProjectDir: '',
@@ -3786,6 +3795,21 @@ export const useAppStore = create<AppState & AppActions>()((set, get) => ({
       return projectSetting;
     }
     return get().useWorktrees;
+  },
+
+  // Dev Server Port Override actions (per-project)
+  setDevServerPort: (projectPath, port) => {
+    set({
+      devServerPortByProject: {
+        ...get().devServerPortByProject,
+        [projectPath]: port,
+      },
+    });
+  },
+
+  getDevServerPort: (projectPath) => {
+    // Returns undefined if not set (use server-provided port)
+    return get().devServerPortByProject[projectPath];
   },
 
   // UI State actions (previously in localStorage, now synced via API)

--- a/libs/types/src/settings.ts
+++ b/libs/types/src/settings.ts
@@ -794,6 +794,10 @@ export interface ProjectSettings {
   automodeEnabled?: boolean;
   /** Maximum concurrent agents for this project (overrides global maxConcurrency) */
   maxConcurrentAgents?: number;
+
+  // Dev Server Configuration
+  /** Custom dev server port to display (for projects where the actual port differs from allocated) */
+  devServerPort?: number;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Adds a new project setting to configure the dev server port display
- Useful for projects where the framework (e.g., Vite, Next.js) ignores the allocated PORT environment variable and uses its own default port
- The configured port is used in toast messages, dropdown displays, and when opening the dev server URL in the browser

## Testing
All tests pass (`npm run test:all`). Feature has been manually tested and verified to work correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)