### PR TITLE
fix: enforce concurrency limit for manual feature execution

### DIFF
--- a/apps/server/src/services/auto-mode-service.ts
+++ b/apps/server/src/services/auto-mode-service.ts
@@ -21,7 +21,12 @@ import type {
   ThinkingLevel,
   PlanningMode,
 } from '@automaker/types';
-import { DEFAULT_PHASE_MODELS, isClaudeModel, stripProviderPrefix } from '@automaker/types';
+import {
+  DEFAULT_GLOBAL_SETTINGS,
+  DEFAULT_PHASE_MODELS,
+  isClaudeModel,
+  stripProviderPrefix,
+} from '@automaker/types';
 import {
   buildPromptWithImages,
   classifyError,
@@ -498,7 +503,11 @@ export class AutoModeService {
     // Check global concurrency limit for manual executions
     // (Auto-mode has its own check in the auto-loop, so skip for isAutoMode)
     if (!isAutoMode) {
-      const maxConcurrency = this.config?.maxConcurrency || 3;
+      const globalSettings = await this.settingsService?.getGlobalSettings();
+      const maxConcurrency =
+        this.config?.maxConcurrency ??
+        globalSettings?.maxConcurrency ??
+        DEFAULT_GLOBAL_SETTINGS.maxConcurrency;
       if (this.runningFeatures.size >= maxConcurrency) {
         throw new Error(
           `Cannot start: ${this.runningFeatures.size}/${maxConcurrency} agents already running`


### PR DESCRIPTION
## Summary
- Add concurrency check at the start of `executeFeature()` method
- Manual "Run" clicks are now subject to the same `maxConcurrency` limit as auto-mode
- Prevents users from exceeding configured agent limit

## Problem
The `maxConcurrency` check only ran in the auto-mode loop (`auto-mode-service.ts:407`), but `run-feature.ts` calls `executeFeature()` directly with no capacity check. This allowed users to bypass the limit by manually clicking "Run" on features, potentially running 8+ agents when max was set to 5.

## Solution
Add concurrency check at the start of `executeFeature()` for non-auto-mode executions:
```typescript
if (!isAutoMode) {
  const maxConcurrency = this.config?.maxConcurrency || 3;
  if (this.runningFeatures.size >= maxConcurrency) {
    throw new Error(`Cannot start: ${this.runningFeatures.size}/${maxConcurrency} agents already running`);
  }
}
```

Auto-mode is skipped since it already has its own check in the auto-loop.

## Test plan
- [ ] Set max concurrent agents to 3
- [ ] Start 3 features manually
- [ ] Try to start a 4th feature manually - should get error message
- [ ] Start auto-mode with 3 running - should wait, not exceed limit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented concurrency limits for manual runs, restricting the maximum number of simultaneously active agents (default: 3, configurable). Auto-mode runs remain unaffected by this limit.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->