### PR TITLE
fix: hide Cursor models in selector when provider is disabled

### DIFF
--- a/apps/ui/src/components/views/settings-view/model-defaults/phase-model-selector.tsx
+++ b/apps/ui/src/components/views/settings-view/model-defaults/phase-model-selector.tsx
@@ -1902,15 +1902,14 @@ export function PhaseModelSelector({
             );
           })}
 
-          {!isCursorDisabled &&
-            (groupedModels.length > 0 || standaloneCursorModels.length > 0) && (
-              <CommandGroup heading="Cursor Models">
-                {/* Grouped models with secondary popover */}
-                {groupedModels.map((group) => renderGroupedModelItem(group))}
-                {/* Standalone models */}
-                {standaloneCursorModels.map((model) => renderCursorModelItem(model))}
-              </CommandGroup>
-            )}
+          {!isCursorDisabled && (groupedModels.length > 0 || standaloneCursorModels.length > 0) && (
+            <CommandGroup heading="Cursor Models">
+              {/* Grouped models with secondary popover */}
+              {groupedModels.map((group) => renderGroupedModelItem(group))}
+              {/* Standalone models */}
+              {standaloneCursorModels.map((model) => renderCursorModelItem(model))}
+            </CommandGroup>
+          )}
 
           {codex.length > 0 && (
             <CommandGroup heading="Codex Models">


### PR DESCRIPTION
## Summary
- Fix bug where Cursor models still appeared in model dropdown selectors when the Cursor provider was disabled in Settings → AI Providers
- Move `isCursorDisabled` check to component level so it can be used in render condition
- Add `!isCursorDisabled &&` check to Cursor Models section, matching the pattern used by other providers

## Problem
When the Cursor provider was toggled OFF in Settings → AI Providers, the "Cursor Models" section still appeared in model selectors (PhaseModelSelector, AgentModelSelector). This was inconsistent with Codex and OpenCode providers, which correctly hide their models when disabled.

## Root Cause
The `groupedModels` and `standaloneCursorModels` variables were derived from `availableCursorModels` without checking if the Cursor provider itself was disabled. The render condition only checked if models existed, not if the provider was enabled.

## Fix
Added `!isCursorDisabled &&` to the render condition for the Cursor Models section, matching the pattern already used in `board-view/shared/model-selector.tsx`.

## Test plan
- [x] Go to Settings → AI Providers
- [x] Toggle OFF the Cursor provider
- [x] Go to Settings → Model Defaults
- [x] Open any model selector dropdown (e.g., Analysis Phase, Coding Phase)
- [x] Verify "Cursor Models" section does NOT appear
- [x] Toggle Cursor provider back ON
- [x] Verify "Cursor Models" section reappears

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the conditional logic for displaying the Cursor Models section based on provider availability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->