### PR TITLE
fix: resolve model aliases in backlog plan explicit override

### DIFF
--- a/apps/server/src/routes/backlog-plan/generate-plan.ts
+++ b/apps/server/src/routes/backlog-plan/generate-plan.ts
@@ -128,7 +128,10 @@ export async function generateBacklogPlan(
     let credentials: import('@automaker/types').Credentials | undefined;
 
     if (effectiveModel) {
-      // Use explicit override - just get credentials
+      // Use explicit override - resolve model alias and get credentials
+      const resolved = resolvePhaseModel({ model: effectiveModel });
+      effectiveModel = resolved.model;
+      thinkingLevel = resolved.thinkingLevel;
       credentials = await settingsService?.getCredentials();
     } else if (settingsService) {
       // Use settings-based model with provider info


### PR DESCRIPTION
## Summary

- Fixes model alias resolution bug in `generateBacklogPlan()` when using explicit model overrides
- Previously, passing `model: "sonnet"` would fail because the API expects full model IDs like `claude-sonnet-4-20250514`

## Problem

In `apps/server/src/routes/backlog-plan/generate-plan.ts`, when an explicit model override was provided, the code only fetched credentials:

```typescript
if (effectiveModel) {
  // Use explicit override - just get credentials
  credentials = await settingsService?.getCredentials();
}
```

The other code branches correctly called `resolvePhaseModel()`:
- **else if (settingsService)** - ✅ Calls `resolvePhaseModel(phaseResult.phaseModel)`
- **else** - ✅ Calls `resolvePhaseModel(DEFAULT_PHASE_MODELS.backlogPlanningModel)`

But the explicit override branch was missing this, causing API calls to fail when using model aliases.

## Solution

Added the missing `resolvePhaseModel()` call to the explicit override branch:

```typescript
if (effectiveModel) {
  // Use explicit override - resolve model alias and get credentials
  const resolved = resolvePhaseModel({ model: effectiveModel });
  effectiveModel = resolved.model;
  thinkingLevel = resolved.thinkingLevel;
  credentials = await settingsService?.getCredentials();
}
```

## Test plan

- [x] Server build passes
- [x] All 1332 server unit tests pass
- [ ] Manual test: Call backlog plan endpoint with explicit model override using an alias (e.g., `model: "sonnet"`) and verify the plan generates successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed model override handling to properly resolve model aliases and apply thinking level settings when a custom model is specified.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->