### PR TITLE
feat(ui): generate meaningful worktree branch names from feature titles

### DIFF
--- a/apps/ui/src/components/views/board-view/hooks/use-board-actions.ts
+++ b/apps/ui/src/components/views/board-view/hooks/use-board-actions.ts
@@ -348,16 +348,21 @@ export function useBoardActions({
         // This ensures features updated on a non-main worktree are associated with that worktree
         finalBranchName = currentWorktreeBranch || undefined;
       } else if (workMode === 'auto') {
-        // Auto-generate a branch name based on feature title and timestamp
-        // Create a slug from the title: lowercase, replace non-alphanumeric with hyphens
-        const titleSlug =
-          titleForBranch
-            .toLowerCase()
-            .replace(/[^a-z0-9]+/g, '-') // Replace non-alphanumeric sequences with hyphens
-            .substring(0, 50) // Limit length first
-            .replace(/^-|-$/g, '') || 'untitled'; // Then remove leading/trailing hyphens, with fallback
-        const randomSuffix = Math.random().toString(36).substring(2, 6);
-        finalBranchName = `feature/${titleSlug}-${randomSuffix}`;
+        // Preserve existing branch name if one exists (avoid orphaning worktrees on edit)
+        if (updates.branchName?.trim()) {
+          finalBranchName = updates.branchName;
+        } else {
+          // Auto-generate a branch name based on feature title
+          // Create a slug from the title: lowercase, replace non-alphanumeric with hyphens
+          const titleSlug =
+            titleForBranch
+              .toLowerCase()
+              .replace(/[^a-z0-9]+/g, '-') // Replace non-alphanumeric sequences with hyphens
+              .substring(0, 50) // Limit length first
+              .replace(/^-|-$/g, '') || 'untitled'; // Then remove leading/trailing hyphens, with fallback
+          const randomSuffix = Math.random().toString(36).substring(2, 6);
+          finalBranchName = `feature/${titleSlug}-${randomSuffix}`;
+        }
       } else {
         finalBranchName = updates.branchName || undefined;
       }


### PR DESCRIPTION
## Summary

This PR reimplements the meaningful worktree names feature from #604, addressing all review feedback.

Instead of generating random branch names like `feature/main-1737547200000-tt2v`, this change creates human-readable branch names based on the feature title: `feature/add-user-authentication-a3b2`

## Changes

- **Meaningful branch names**: Generate branch name slug from feature title (lowercase, alphanumeric, hyphens)
- **Shorter suffix**: Use 4-character random suffix for uniqueness instead of timestamp
- **Title generation**: If no title provided in auto worktree mode, generate one from description first
- **Fallback handling**: Fall back to 'untitled' if both title and description are empty
- **Bug fix from review**: Apply substring limit (50 chars) _before_ removing trailing hyphens to prevent malformed branch names when truncation occurs at a hyphen position

## Review Comments Addressed

From the original PR #604 reviews:

| Comment | Status |
|---------|--------|
| [CodeRabbit] Edge case: empty title/description | ✅ Handled via `\|\| 'untitled'` fallback |
| [Gemini HIGH] Substring order causing trailing hyphens | ✅ Fixed - `.substring(0, 50)` now before `.replace(/^-\|-$/g, '')` |
| [Gemini HIGH] Missing background title gen in update | ⏭️ Intentionally different - CREATE auto-generates, UPDATE respects user choice |
| [Gemini MEDIUM] DRY principle violation | ⏭️ Skipped - only 2 places, clear code, minimal benefit from abstraction |

## Example

Before:
```
feature/main-1737547200000-tt2v
feature/main-1737547300000-x9kp
```

After:
```
feature/add-user-authentication-a3b2
feature/fix-login-validation-x9kp
```

## Test plan

- [ ] Create a new feature with auto worktree mode and verify branch name is based on title
- [ ] Create a feature without title (only description) and verify title is generated for branch name
- [ ] Create a feature with a very long title (>50 chars) and verify branch name is properly truncated without trailing hyphens
- [ ] Create a feature with special characters in title and verify they're converted to hyphens
- [ ] Update an existing feature to auto worktree mode and verify branch name generation works

Closes #604

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic title generation from descriptions when using auto work mode, including on updates.

* **Improvements**
  * New slug-based branch naming for clearer, more consistent branch names.
  * Generated titles now propagate to feature titles and are computed in background with progress indication.
  * More reliable branch/worktree creation and consistent behavior across add/update flows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->