### PR TITLE
fix: update structured output logic in spec generation for non claude and codex models

### DIFF
--- a/apps/server/src/routes/app-spec/generate-spec.ts
+++ b/apps/server/src/routes/app-spec/generate-spec.ts
@@ -9,7 +9,7 @@ import * as secureFs from '../../lib/secure-fs.js';
 import type { EventEmitter } from '../../lib/events.js';
 import { specOutputSchema, specToXml, type SpecOutput } from '../../lib/app-spec-format.js';
 import { createLogger } from '@automaker/utils';
-import { DEFAULT_PHASE_MODELS, isCursorModel } from '@automaker/types';
+import { DEFAULT_PHASE_MODELS, isClaudeModel, isCodexModel } from '@automaker/types';
 import { resolvePhaseModel } from '@automaker/model-resolver';
 import { extractJson } from '../../lib/json-extractor.js';
 import { streamingQuery } from '../../providers/simple-query-service.js';
@@ -120,8 +120,8 @@ ${prompts.appSpec.structuredSpecInstructions}`;
   let responseText = '';
   let structuredOutput: SpecOutput | null = null;
 
-  // Determine if we should use structured output (Claude supports it, Cursor doesn't)
-  const useStructuredOutput = !isCursorModel(model);
+  // Determine if we should use structured output (only Claude and Codex support it)
+  const useStructuredOutput = isClaudeModel(model) || isCodexModel(model);
 
   // Build the final prompt - for Cursor, include JSON schema instructions
   let finalPrompt = prompt;


### PR DESCRIPTION
- Modify the condition for using structured output to include both Claude and Codex models, ensuring compatibility with the latest model capabilities.