### PR TITLE
fix: add proper margin between icon and green dot in auto mode menu item

### DIFF
--- a/apps/ui/src/components/views/board-view/worktree-panel/components/worktree-actions-dropdown.tsx
+++ b/apps/ui/src/components/views/board-view/worktree-panel/components/worktree-actions-dropdown.tsx
@@ -319,7 +319,7 @@ export function WorktreeActionsDropdown({
               <DropdownMenuItem onClick={() => onToggleAutoMode(worktree)} className="text-xs">
                 <span className="flex items-center mr-2">
                   <Zap className="w-3.5 h-3.5 text-yellow-500" />
-                  <span className="ml-0.5 h-2 w-2 rounded-full bg-green-500 animate-pulse" />
+                  <span className="ml-1.5 h-2 w-2 rounded-full bg-green-500 animate-pulse" />
                 </span>
                 Stop Auto Mode
               </DropdownMenuItem>


### PR DESCRIPTION
## Summary
- Fixed missing margin between lightning bolt icon and green dot indicator in the "Stop Auto Mode" dropdown menu item
- Increased margin from `ml-0.5` (2px) to `ml-1.5` (6px) for proper visual spacing

Closes #672

## Test plan
- [x] Run auto mode on any worktree
- [x] Open the dropdown menu from the worktree panel
- [x] Verify proper spacing between the lightning icon and green dot in "Stop Auto Mode" item

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined the spacing of the Auto Mode indicator element in the worktree actions menu for improved visual alignment.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->