### PR TITLE
Fix: Column header overflow and title wrapping in Kanban board

### DIFF
--- a/apps/ui/src/components/views/board-view/components/kanban-column.tsx
+++ b/apps/ui/src/components/views/board-view/components/kanban-column.tsx
@@ -78,7 +78,9 @@ export const KanbanColumn = memo(function KanbanColumn({
         )}
       >
         <div className={cn('w-2.5 h-2.5 rounded-full shrink-0', colorClass)} />
-        <h3 className="font-semibold text-sm text-foreground/90 flex-1 tracking-tight">{title}</h3>
+        <h3 className="font-semibold text-sm text-foreground/90 flex-1 tracking-tight whitespace-nowrap">
+          {title}
+        </h3>
         {headerAction}
         <span className="text-xs font-medium text-muted-foreground/80 bg-muted/50 px-2 py-0.5 rounded-md tabular-nums">
           {count}

--- a/apps/ui/src/components/views/board-view/components/list-view/list-header.tsx
+++ b/apps/ui/src/components/views/board-view/components/list-view/list-header.tsx
@@ -132,7 +132,7 @@ const SortableColumnHeader = memo(function SortableColumnHeader({
       )}
       data-testid={`list-header-${column.id}`}
     >
-      <span>{column.label}</span>
+      <span className="whitespace-nowrap truncate">{column.label}</span>
       <SortIcon column={column.id} sortConfig={sortConfig} />
     </div>
   );
@@ -156,7 +156,7 @@ const StaticColumnHeader = memo(function StaticColumnHeader({ column }: { column
       )}
       data-testid={`list-header-${column.id}`}
     >
-      <span>{column.label}</span>
+      <span className="whitespace-nowrap truncate">{column.label}</span>
     </div>
   );
 });

--- a/apps/ui/src/components/views/board-view/kanban-board.tsx
+++ b/apps/ui/src/components/views/board-view/kanban-board.tsx
@@ -12,7 +12,8 @@ import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable'
 import { Button } from '@/components/ui/button';
 import { KanbanColumn, KanbanCard, EmptyStateCard } from './components';
 import { Feature, useAppStore, formatShortcut } from '@/store/app-store';
-import { Archive, Settings2, CheckSquare, GripVertical, Plus } from 'lucide-react';
+import { Archive, Settings2, CheckSquare, GripVertical, Plus, CheckCircle2 } from 'lucide-react';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { useResponsiveKanban } from '@/hooks/use-responsive-kanban';
 import { getColumnsWithPipeline, type ColumnId } from './constants';
 import type { PipelineConfig } from '@automaker/types';
@@ -357,35 +358,49 @@ export function KanbanBoard({
                   contentClassName="perf-contain"
                   headerAction={
                     column.id === 'verified' ? (
-                      <div className="flex items-center gap-1">
-                        {columnFeatures.length > 0 && (
-                          <Button
-                            variant="ghost"
-                            size="sm"
-                            className="h-6 px-2 text-xs"
-                            onClick={onArchiveAllVerified}
-                            data-testid="archive-all-verified-button"
-                          >
-                            <Archive className="w-3 h-3 mr-1" />
-                            Complete All
-                          </Button>
-                        )}
-                        <Button
-                          variant="ghost"
-                          size="sm"
-                          className="h-6 w-6 p-0 relative"
-                          onClick={onShowCompletedModal}
-                          title={`Completed Features (${completedCount})`}
-                          data-testid="completed-features-button"
-                        >
-                          <Archive className="w-3.5 h-3.5 text-muted-foreground" />
-                          {completedCount > 0 && (
-                            <span className="absolute -top-1 -right-1 bg-brand-500 text-white text-[8px] font-bold rounded-full w-3.5 h-3.5 flex items-center justify-center">
-                              {completedCount > 99 ? '99+' : completedCount}
-                            </span>
+                      <TooltipProvider>
+                        <div className="flex items-center gap-1">
+                          {columnFeatures.length > 0 && (
+                            <Tooltip>
+                              <TooltipTrigger asChild>
+                                <Button
+                                  variant="ghost"
+                                  size="sm"
+                                  className="h-6 w-6 p-0"
+                                  onClick={onArchiveAllVerified}
+                                  data-testid="archive-all-verified-button"
+                                >
+                                  <CheckCircle2 className="w-3.5 h-3.5" />
+                                </Button>
+                              </TooltipTrigger>
+                              <TooltipContent>
+                                <p>Complete All</p>
+                              </TooltipContent>
+                            </Tooltip>
                           )}
-                        </Button>
-                      </div>
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <Button
+                                variant="ghost"
+                                size="sm"
+                                className="h-6 w-6 p-0 relative"
+                                onClick={onShowCompletedModal}
+                                data-testid="completed-features-button"
+                              >
+                                <Archive className="w-3.5 h-3.5 text-muted-foreground" />
+                                {completedCount > 0 && (
+                                  <span className="absolute -top-1 -right-1 bg-brand-500 text-white text-[8px] font-bold rounded-full w-3.5 h-3.5 flex items-center justify-center">
+                                    {completedCount > 99 ? '99+' : completedCount}
+                                  </span>
+                                )}
+                              </Button>
+                            </TooltipTrigger>
+                            <TooltipContent>
+                              <p>Completed Features ({completedCount})</p>
+                            </TooltipContent>
+                          </Tooltip>
+                        </div>
+                      </TooltipProvider>
                     ) : column.id === 'backlog' ? (
                       <div className="flex items-center gap-1">
                         <Button

--- a/apps/ui/src/hooks/use-responsive-kanban.ts
+++ b/apps/ui/src/hooks/use-responsive-kanban.ts
@@ -14,8 +14,8 @@ export interface ResponsiveKanbanConfig {
  * Default configuration for responsive Kanban columns
  */
 const DEFAULT_CONFIG: ResponsiveKanbanConfig = {
-  columnWidth: 288, // 18rem = 288px (w-72)
-  columnMinWidth: 280, // Minimum column width - ensures usability
+  columnWidth: 320, // Increased from 288px to accommodate longer column titles
+  columnMinWidth: 320, // Increased from 280px to prevent title overflow
   columnMaxWidth: Infinity, // No max width - columns scale evenly to fill viewport
   gap: 20, // gap-5 = 20px
   padding: 40, // px-5 on both sides = 40px (matches gap between columns)


### PR DESCRIPTION
## Summary

Fixes column header inconsistencies in the Kanban board by preventing title wrapping and optimizing header button layout for narrow column widths.

## Changes

### 1. Column Title Handling
- Added `whitespace-nowrap` to column titles to prevent wrapping to multiple lines
- Increased minimum column width from 280px to 320px to accommodate longer titles like "Waiting Approval"

### 2. Verified Column Header Actions
- Changed "Complete All" button icon from `Archive` to `CheckCircle2` for better visual distinction
- Replaced native `title` tooltips with proper `Tooltip` component for both action buttons
- Wrapped both buttons (Complete All and Completed Features) with `TooltipProvider` for consistent UX

### 3. List View Headers
- Applied `whitespace-nowrap` to list view column headers for consistency

## Files Modified

- `apps/ui/src/components/views/board-view/components/kanban-column.tsx`
- `apps/ui/src/components/views/board-view/kanban-board.tsx`
- `apps/ui/src/components/list-view/list-header.tsx`
- `apps/ui/src/hooks/use-responsive-kanban.ts`

## Testing

- [x] Verified titles no longer wrap at narrow column widths
- [x] Verified header actions fit properly in the Verified column
- [x] Verified consistent column header heights across all columns
- [x] Verified tooltips display correctly on hover

## Screenshots

Before: Column titles wrapping and header overflow
After: Consistent column headers with proper tooltips

Closes #691

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>