### PR TITLE
fix: Check Claude Code CLI auth before showing warning

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -133,7 +133,8 @@ const BOX_CONTENT_WIDTH = 67;
     const hasCliAuth =
       indicators.hasStatsCacheWithActivity ||
       (indicators.hasSettingsFile && indicators.hasProjectsSessions) ||
-      (indicators.hasCredentialsFile && indicators.credentials?.hasOAuthToken);
+      (indicators.hasCredentialsFile &&
+        (indicators.credentials?.hasOAuthToken || indicators.credentials?.hasApiKey));
 
     if (hasCliAuth) {
       logger.info('✓ Claude Code CLI authentication detected');


### PR DESCRIPTION
## Summary
- Fixed false positive "No Claude authentication configured" warning that appeared even when users have Claude Code CLI installed and authenticated with a subscription
- The Claude Agent SDK can reuse CLI authentication, so the warning was misleading
- Now checks for Claude Code CLI authentication indicators (settings, sessions, credentials) before showing the warning
- Updated warning message to list all three authentication options clearly

## Test plan
- [x] Start server without `ANTHROPIC_API_KEY` but with Claude Code CLI authenticated → should show `✓ Claude Code CLI authentication detected`
- [x] Start server without any authentication → should show the updated warning with all 3 options
- [x] Start server with `ANTHROPIC_API_KEY` set → should show `✓ ANTHROPIC_API_KEY detected`

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced startup authentication detection that checks multiple authentication methods in the background and logs outcomes.
  * Improved warning dialog with clearer, option-based guidance (CLI, API key, or setup wizard) when no authentication is found.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->