### PR TITLE
refactor(store): Extract default values into store/defaults/

### DIFF
--- a/apps/ui/src/store/app-store.ts
+++ b/apps/ui/src/store/app-store.ts
@@ -5,11 +5,7 @@ import { getElectronAPI } from '@/lib/electron';
 import { getHttpApiClient } from '@/lib/http-api-client';
 import { createLogger } from '@automaker/utils/logger';
 // Note: setItem/getItem moved to ./utils/theme-utils.ts
-import {
-  UI_SANS_FONT_OPTIONS,
-  UI_MONO_FONT_OPTIONS,
-  DEFAULT_FONT_VALUE,
-} from '@/config/ui-font-options';
+import { UI_SANS_FONT_OPTIONS, UI_MONO_FONT_OPTIONS } from '@/config/ui-font-options';
 import type {
   Feature as BaseFeature,
   FeatureImagePath,
@@ -63,6 +59,7 @@ import {
   type BoardViewMode,
   type ShortcutKey,
   type KeyboardShortcuts,
+  type BackgroundSettings,
   // Settings types
   type ApiKeys,
   // Chat types
@@ -111,6 +108,9 @@ import {
   isClaudeUsageAtLimit,
 } from './utils';
 
+// Import default values from modular defaults files
+import { defaultBackgroundSettings, defaultTerminalState, MAX_INIT_OUTPUT_LINES } from './defaults';
+
 // Import internal theme utils (not re-exported publicly)
 import {
   getEffectiveFont,
@@ -145,6 +145,7 @@ export type {
   BoardViewMode,
   ShortcutKey,
   KeyboardShortcuts,
+  BackgroundSettings,
   ApiKeys,
   ImageAttachment,
   TextFileAttachment,
@@ -189,6 +190,9 @@ export {
   isClaudeUsageAtLimit,
 };
 
+// Re-export defaults from ./defaults for backward compatibility
+export { defaultBackgroundSettings, defaultTerminalState, MAX_INIT_OUTPUT_LINES } from './defaults';
+
 // NOTE: Type definitions moved to ./types/ directory, utilities moved to ./utils/ directory
 // The following inline types have been replaced with imports above:
 // - ViewMode, ThemeMode, BoardViewMode (./types/ui-types.ts)
@@ -203,31 +207,10 @@ export {
 // - Theme utilities: THEME_STORAGE_KEY, getStoredTheme, getStoredFontSans, getStoredFontMono, etc. (./utils/theme-utils.ts)
 // - Shortcut utilities: parseShortcut, formatShortcut, DEFAULT_KEYBOARD_SHORTCUTS (./utils/shortcut-utils.ts)
 // - Usage utilities: isClaudeUsageAtLimit (./utils/usage-utils.ts)
-
-// Maximum number of output lines to keep in init script state (prevents unbounded memory growth)
-export const MAX_INIT_OUTPUT_LINES = 500;
-
-// Default background settings for board backgrounds
-export const defaultBackgroundSettings: {
-  imagePath: string | null;
-  imageVersion?: number;
-  cardOpacity: number;
-  columnOpacity: number;
-  columnBorderEnabled: boolean;
-  cardGlassmorphism: boolean;
-  cardBorderEnabled: boolean;
-  cardBorderOpacity: number;
-  hideScrollbar: boolean;
-} = {
-  imagePath: null,
-  cardOpacity: 100,
-  columnOpacity: 100,
-  columnBorderEnabled: true,
-  cardGlassmorphism: true,
-  cardBorderEnabled: true,
-  cardBorderOpacity: 100,
-  hideScrollbar: false,
-};
+// The following default values have been moved to ./defaults/:
+// - MAX_INIT_OUTPUT_LINES (./defaults/constants.ts)
+// - defaultBackgroundSettings (./defaults/background-settings.ts)
+// - defaultTerminalState (./defaults/terminal-defaults.ts)
 
 const initialState: AppState = {
   projects: [],
@@ -319,23 +302,7 @@ const initialState: AppState = {
   isAnalyzing: false,
   boardBackgroundByProject: {},
   previewTheme: null,
-  terminalState: {
-    isUnlocked: false,
-    authToken: null,
-    tabs: [],
-    activeTabId: null,
-    activeSessionId: null,
-    maximizedSessionId: null,
-    defaultFontSize: 14,
-    defaultRunScript: '',
-    screenReaderMode: false,
-    fontFamily: DEFAULT_FONT_VALUE,
-    scrollbackLines: 5000,
-    lineHeight: 1.0,
-    maxSessions: 100,
-    lastActiveProjectPath: null,
-    openTerminalMode: 'newTab',
-  },
+  terminalState: defaultTerminalState,
   terminalLayoutByProject: {},
   specCreatingForProject: null,
   defaultPlanningMode: 'skip' as PlanningMode,

--- a/apps/ui/src/store/defaults/background-settings.ts
+++ b/apps/ui/src/store/defaults/background-settings.ts
@@ -1,0 +1,13 @@
+import type { BackgroundSettings } from '../types/ui-types';
+
+// Default background settings for board backgrounds
+export const defaultBackgroundSettings: BackgroundSettings = {
+  imagePath: null,
+  cardOpacity: 100,
+  columnOpacity: 100,
+  columnBorderEnabled: true,
+  cardGlassmorphism: true,
+  cardBorderEnabled: true,
+  cardBorderOpacity: 100,
+  hideScrollbar: false,
+};

--- a/apps/ui/src/store/defaults/constants.ts
+++ b/apps/ui/src/store/defaults/constants.ts
@@ -1,0 +1,2 @@
+// Maximum number of output lines to keep in init script state (prevents unbounded memory growth)
+export const MAX_INIT_OUTPUT_LINES = 500;

--- a/apps/ui/src/store/defaults/index.ts
+++ b/apps/ui/src/store/defaults/index.ts
@@ -1,0 +1,3 @@
+export { defaultBackgroundSettings } from './background-settings';
+export { defaultTerminalState } from './terminal-defaults';
+export { MAX_INIT_OUTPUT_LINES } from './constants';

--- a/apps/ui/src/store/defaults/terminal-defaults.ts
+++ b/apps/ui/src/store/defaults/terminal-defaults.ts
@@ -1,0 +1,21 @@
+import { DEFAULT_FONT_VALUE } from '@/config/ui-font-options';
+import type { TerminalState } from '../types/terminal-types';
+
+// Default terminal state values
+export const defaultTerminalState: TerminalState = {
+  isUnlocked: false,
+  authToken: null,
+  tabs: [],
+  activeTabId: null,
+  activeSessionId: null,
+  maximizedSessionId: null,
+  defaultFontSize: 14,
+  defaultRunScript: '',
+  screenReaderMode: false,
+  fontFamily: DEFAULT_FONT_VALUE,
+  scrollbackLines: 5000,
+  lineHeight: 1.0,
+  maxSessions: 100,
+  lastActiveProjectPath: null,
+  openTerminalMode: 'newTab',
+};

--- a/apps/ui/src/store/types/state-types.ts
+++ b/apps/ui/src/store/types/state-types.ts
@@ -25,7 +25,13 @@ import type {
   SidebarStyle,
 } from '@automaker/types';
 
-import type { ViewMode, ThemeMode, BoardViewMode, KeyboardShortcuts } from './ui-types';
+import type {
+  ViewMode,
+  ThemeMode,
+  BoardViewMode,
+  KeyboardShortcuts,
+  BackgroundSettings,
+} from './ui-types';
 import type { ApiKeys } from './settings-types';
 import type { ChatMessage, ChatSession, FeatureImage } from './chat-types';
 import type { TerminalState, TerminalPanelContent, PersistedTerminalState } from './terminal-types';
@@ -253,20 +259,7 @@ export interface AppState {
   isAnalyzing: boolean;
 
   // Board Background Settings (per-project, keyed by project path)
-  boardBackgroundByProject: Record<
-    string,
-    {
-      imagePath: string | null; // Path to background image in .automaker directory
-      imageVersion?: number; // Timestamp to bust browser cache when image is updated
-      cardOpacity: number; // Opacity of cards (0-100)
-      columnOpacity: number; // Opacity of columns (0-100)
-      columnBorderEnabled: boolean; // Whether to show column borders
-      cardGlassmorphism: boolean; // Whether to use glassmorphism (backdrop-blur) on cards
-      cardBorderEnabled: boolean; // Whether to show card borders
-      cardBorderOpacity: number; // Opacity of card borders (0-100)
-      hideScrollbar: boolean; // Whether to hide the board scrollbar
-    }
-  >;
+  boardBackgroundByProject: Record<string, BackgroundSettings>;
 
   // Theme Preview (for hover preview in theme selectors)
   previewTheme: ThemeMode | null;

--- a/apps/ui/src/store/types/ui-types.ts
+++ b/apps/ui/src/store/types/ui-types.ts
@@ -68,6 +68,19 @@ export interface ShortcutKey {
   alt?: boolean; // Alt/Option key modifier
 }
 
+// Board background settings
+export interface BackgroundSettings {
+  imagePath: string | null;
+  imageVersion?: number;
+  cardOpacity: number;
+  columnOpacity: number;
+  columnBorderEnabled: boolean;
+  cardGlassmorphism: boolean;
+  cardBorderEnabled: boolean;
+  cardBorderOpacity: number;
+  hideScrollbar: boolean;
+}
+
 // Keyboard Shortcuts - stored as strings like "K", "Shift+N", "Cmd+K"
 export interface KeyboardShortcuts {
   // Navigation shortcuts


### PR DESCRIPTION
## Summary

- Extract default values and constants from `app-store.ts` into a modular `store/defaults/` directory
- Add `BackgroundSettings` type to `store/types/ui-types.ts`
- Maintain backward compatibility through re-exports from `app-store.ts`

## Changes

### New Files Created (`apps/ui/src/store/defaults/`)

| File | Contents | Lines |
|------|----------|-------|
| `constants.ts` | MAX_INIT_OUTPUT_LINES | 2 |
| `background-settings.ts` | defaultBackgroundSettings | 13 |
| `terminal-defaults.ts` | defaultTerminalState | 19 |
| `index.ts` | Re-exports all defaults | 3 |

### Files Modified

| File | Changes |
|------|---------|
| `apps/ui/src/store/types/ui-types.ts` | Added `BackgroundSettings` interface |
| `apps/ui/src/store/types/state-types.ts` | Updated `boardBackgroundByProject` to use `BackgroundSettings` type |
| `apps/ui/src/store/app-store.ts` | Import defaults from `./defaults`, remove inline definitions, update re-exports |

## Backward Compatibility

All existing imports from `@/store/app-store` continue to work:
```typescript
// These still work
import { defaultBackgroundSettings, defaultTerminalState, MAX_INIT_OUTPUT_LINES } from '@/store/app-store';
```

New canonical import path:
```typescript
import { defaultBackgroundSettings, defaultTerminalState, MAX_INIT_OUTPUT_LINES } from '@/store/defaults';
```

## Test Plan

- [x] Build succeeds (`npm run build`)
- [x] Lint passes (`npm run lint` - 0 errors)
- [x] Package tests pass (`npm run test:packages` - 519 tests)
- [x] Server tests pass (`npm run test:server` - 1,415 tests)

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized default configuration management by consolidating terminal state, background settings, and initialization constants into a dedicated modular structure.
  * Maintained backward compatibility through strategic re-exports of configuration constants.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->