### PR TITLE
refactor(store): Extract UI slice from app-store.ts

### DIFF
--- a/apps/ui/src/store/slices/index.ts
+++ b/apps/ui/src/store/slices/index.ts
@@ -1,0 +1,1 @@
+export { createUISlice, initialUIState, type UISlice } from './ui-slice';

--- a/apps/ui/src/store/slices/ui-slice.ts
+++ b/apps/ui/src/store/slices/ui-slice.ts
@@ -1,0 +1,343 @@
+import type { StateCreator } from 'zustand';
+import { UI_SANS_FONT_OPTIONS, UI_MONO_FONT_OPTIONS } from '@/config/ui-font-options';
+import type { SidebarStyle } from '@automaker/types';
+import type {
+  ViewMode,
+  ThemeMode,
+  BoardViewMode,
+  KeyboardShortcuts,
+  BackgroundSettings,
+  UISliceState,
+  UISliceActions,
+} from '../types/ui-types';
+import type { AppState, AppActions } from '../types/state-types';
+import {
+  getStoredTheme,
+  getStoredFontSans,
+  getStoredFontMono,
+  DEFAULT_KEYBOARD_SHORTCUTS,
+} from '../utils';
+import { defaultBackgroundSettings } from '../defaults';
+import {
+  getEffectiveFont,
+  saveThemeToStorage,
+  saveFontSansToStorage,
+  saveFontMonoToStorage,
+} from '../utils/theme-utils';
+
+/**
+ * UI Slice
+ * Contains all UI-related state and actions extracted from the main app store.
+ * This is the first slice pattern implementation in the codebase.
+ */
+export type UISlice = UISliceState & UISliceActions;
+
+/**
+ * Initial UI state values
+ */
+export const initialUIState: UISliceState = {
+  // Core UI State
+  currentView: 'welcome',
+  sidebarOpen: true,
+  sidebarStyle: 'unified',
+  collapsedNavSections: {},
+  mobileSidebarHidden: false,
+
+  // Theme State
+  theme: getStoredTheme() || 'dark',
+  previewTheme: null,
+
+  // Font State
+  fontFamilySans: getStoredFontSans(),
+  fontFamilyMono: getStoredFontMono(),
+
+  // Board UI State
+  boardViewMode: 'kanban',
+  boardBackgroundByProject: {},
+
+  // Settings UI State
+  keyboardShortcuts: DEFAULT_KEYBOARD_SHORTCUTS,
+  muteDoneSound: false,
+  disableSplashScreen: false,
+  showQueryDevtools: true,
+  chatHistoryOpen: false,
+
+  // Panel Visibility State
+  worktreePanelCollapsed: false,
+  worktreePanelVisibleByProject: {},
+  showInitScriptIndicatorByProject: {},
+  autoDismissInitScriptIndicatorByProject: {},
+
+  // File Picker UI State
+  lastProjectDir: '',
+  recentFolders: [],
+};
+
+/**
+ * Creates the UI slice for the Zustand store.
+ *
+ * Uses the StateCreator pattern to allow the slice to access other parts
+ * of the combined store state (e.g., currentProject for theme resolution).
+ */
+export const createUISlice: StateCreator<AppState & AppActions, [], [], UISlice> = (set, get) => ({
+  // Spread initial state
+  ...initialUIState,
+
+  // ============================================================================
+  // View Actions
+  // ============================================================================
+
+  setCurrentView: (view: ViewMode) => set({ currentView: view }),
+
+  toggleSidebar: () => set((state) => ({ sidebarOpen: !state.sidebarOpen })),
+
+  setSidebarOpen: (open: boolean) => set({ sidebarOpen: open }),
+
+  setSidebarStyle: (style: SidebarStyle) => set({ sidebarStyle: style }),
+
+  setCollapsedNavSections: (sections: Record<string, boolean>) =>
+    set({ collapsedNavSections: sections }),
+
+  toggleNavSection: (sectionLabel: string) =>
+    set((state) => ({
+      collapsedNavSections: {
+        ...state.collapsedNavSections,
+        [sectionLabel]: !state.collapsedNavSections[sectionLabel],
+      },
+    })),
+
+  toggleMobileSidebarHidden: () =>
+    set((state) => ({ mobileSidebarHidden: !state.mobileSidebarHidden })),
+
+  setMobileSidebarHidden: (hidden: boolean) => set({ mobileSidebarHidden: hidden }),
+
+  // ============================================================================
+  // Theme Actions
+  // ============================================================================
+
+  setTheme: (theme: ThemeMode) => {
+    set({ theme });
+    saveThemeToStorage(theme);
+  },
+
+  getEffectiveTheme: (): ThemeMode => {
+    const state = get();
+    // If there's a preview theme, use it (for hover preview)
+    if (state.previewTheme) return state.previewTheme;
+    // Otherwise, use project theme if set, or fall back to global theme
+    const projectTheme = state.currentProject?.theme as ThemeMode | undefined;
+    return projectTheme ?? state.theme;
+  },
+
+  setPreviewTheme: (theme: ThemeMode | null) => set({ previewTheme: theme }),
+
+  // ============================================================================
+  // Font Actions
+  // ============================================================================
+
+  setFontSans: (fontFamily: string | null) => {
+    set({ fontFamilySans: fontFamily });
+    saveFontSansToStorage(fontFamily);
+  },
+
+  setFontMono: (fontFamily: string | null) => {
+    set({ fontFamilyMono: fontFamily });
+    saveFontMonoToStorage(fontFamily);
+  },
+
+  getEffectiveFontSans: (): string | null => {
+    const state = get();
+    const projectFont = state.currentProject?.fontFamilySans;
+    return getEffectiveFont(projectFont, state.fontFamilySans, UI_SANS_FONT_OPTIONS);
+  },
+
+  getEffectiveFontMono: (): string | null => {
+    const state = get();
+    const projectFont = state.currentProject?.fontFamilyMono;
+    return getEffectiveFont(projectFont, state.fontFamilyMono, UI_MONO_FONT_OPTIONS);
+  },
+
+  // ============================================================================
+  // Board View Actions
+  // ============================================================================
+
+  setBoardViewMode: (mode: BoardViewMode) => set({ boardViewMode: mode }),
+
+  setBoardBackground: (projectPath: string, imagePath: string | null) =>
+    set((state) => ({
+      boardBackgroundByProject: {
+        ...state.boardBackgroundByProject,
+        [projectPath]: {
+          ...(state.boardBackgroundByProject[projectPath] ?? defaultBackgroundSettings),
+          imagePath,
+          imageVersion: Date.now(), // Bust cache on image change
+        },
+      },
+    })),
+
+  setCardOpacity: (projectPath: string, opacity: number) =>
+    set((state) => ({
+      boardBackgroundByProject: {
+        ...state.boardBackgroundByProject,
+        [projectPath]: {
+          ...(state.boardBackgroundByProject[projectPath] ?? defaultBackgroundSettings),
+          cardOpacity: opacity,
+        },
+      },
+    })),
+
+  setColumnOpacity: (projectPath: string, opacity: number) =>
+    set((state) => ({
+      boardBackgroundByProject: {
+        ...state.boardBackgroundByProject,
+        [projectPath]: {
+          ...(state.boardBackgroundByProject[projectPath] ?? defaultBackgroundSettings),
+          columnOpacity: opacity,
+        },
+      },
+    })),
+
+  setColumnBorderEnabled: (projectPath: string, enabled: boolean) =>
+    set((state) => ({
+      boardBackgroundByProject: {
+        ...state.boardBackgroundByProject,
+        [projectPath]: {
+          ...(state.boardBackgroundByProject[projectPath] ?? defaultBackgroundSettings),
+          columnBorderEnabled: enabled,
+        },
+      },
+    })),
+
+  setCardGlassmorphism: (projectPath: string, enabled: boolean) =>
+    set((state) => ({
+      boardBackgroundByProject: {
+        ...state.boardBackgroundByProject,
+        [projectPath]: {
+          ...(state.boardBackgroundByProject[projectPath] ?? defaultBackgroundSettings),
+          cardGlassmorphism: enabled,
+        },
+      },
+    })),
+
+  setCardBorderEnabled: (projectPath: string, enabled: boolean) =>
+    set((state) => ({
+      boardBackgroundByProject: {
+        ...state.boardBackgroundByProject,
+        [projectPath]: {
+          ...(state.boardBackgroundByProject[projectPath] ?? defaultBackgroundSettings),
+          cardBorderEnabled: enabled,
+        },
+      },
+    })),
+
+  setCardBorderOpacity: (projectPath: string, opacity: number) =>
+    set((state) => ({
+      boardBackgroundByProject: {
+        ...state.boardBackgroundByProject,
+        [projectPath]: {
+          ...(state.boardBackgroundByProject[projectPath] ?? defaultBackgroundSettings),
+          cardBorderOpacity: opacity,
+        },
+      },
+    })),
+
+  setHideScrollbar: (projectPath: string, hide: boolean) =>
+    set((state) => ({
+      boardBackgroundByProject: {
+        ...state.boardBackgroundByProject,
+        [projectPath]: {
+          ...(state.boardBackgroundByProject[projectPath] ?? defaultBackgroundSettings),
+          hideScrollbar: hide,
+        },
+      },
+    })),
+
+  getBoardBackground: (projectPath: string): BackgroundSettings =>
+    get().boardBackgroundByProject[projectPath] ?? defaultBackgroundSettings,
+
+  clearBoardBackground: (projectPath: string) =>
+    set((state) => {
+      const newBackgrounds = { ...state.boardBackgroundByProject };
+      delete newBackgrounds[projectPath];
+      return { boardBackgroundByProject: newBackgrounds };
+    }),
+
+  // ============================================================================
+  // Settings UI Actions
+  // ============================================================================
+
+  setKeyboardShortcut: (key: keyof KeyboardShortcuts, value: string) =>
+    set((state) => ({
+      keyboardShortcuts: { ...state.keyboardShortcuts, [key]: value },
+    })),
+
+  setKeyboardShortcuts: (shortcuts: Partial<KeyboardShortcuts>) =>
+    set((state) => ({
+      keyboardShortcuts: { ...state.keyboardShortcuts, ...shortcuts },
+    })),
+
+  resetKeyboardShortcuts: () => set({ keyboardShortcuts: DEFAULT_KEYBOARD_SHORTCUTS }),
+
+  setMuteDoneSound: (muted: boolean) => set({ muteDoneSound: muted }),
+
+  setDisableSplashScreen: (disabled: boolean) => set({ disableSplashScreen: disabled }),
+
+  setShowQueryDevtools: (show: boolean) => set({ showQueryDevtools: show }),
+
+  setChatHistoryOpen: (open: boolean) => set({ chatHistoryOpen: open }),
+
+  toggleChatHistory: () => set((state) => ({ chatHistoryOpen: !state.chatHistoryOpen })),
+
+  // ============================================================================
+  // Panel Visibility Actions
+  // ============================================================================
+
+  setWorktreePanelCollapsed: (collapsed: boolean) => set({ worktreePanelCollapsed: collapsed }),
+
+  setWorktreePanelVisible: (projectPath: string, visible: boolean) =>
+    set((state) => ({
+      worktreePanelVisibleByProject: {
+        ...state.worktreePanelVisibleByProject,
+        [projectPath]: visible,
+      },
+    })),
+
+  getWorktreePanelVisible: (projectPath: string): boolean =>
+    get().worktreePanelVisibleByProject[projectPath] ?? true,
+
+  setShowInitScriptIndicator: (projectPath: string, visible: boolean) =>
+    set((state) => ({
+      showInitScriptIndicatorByProject: {
+        ...state.showInitScriptIndicatorByProject,
+        [projectPath]: visible,
+      },
+    })),
+
+  getShowInitScriptIndicator: (projectPath: string): boolean =>
+    get().showInitScriptIndicatorByProject[projectPath] ?? true,
+
+  setAutoDismissInitScriptIndicator: (projectPath: string, autoDismiss: boolean) =>
+    set((state) => ({
+      autoDismissInitScriptIndicatorByProject: {
+        ...state.autoDismissInitScriptIndicatorByProject,
+        [projectPath]: autoDismiss,
+      },
+    })),
+
+  getAutoDismissInitScriptIndicator: (projectPath: string): boolean =>
+    get().autoDismissInitScriptIndicatorByProject[projectPath] ?? true,
+
+  // ============================================================================
+  // File Picker UI Actions
+  // ============================================================================
+
+  setLastProjectDir: (dir: string) => set({ lastProjectDir: dir }),
+
+  setRecentFolders: (folders: string[]) => set({ recentFolders: folders }),
+
+  addRecentFolder: (folder: string) =>
+    set((state) => {
+      const filtered = state.recentFolders.filter((f) => f !== folder);
+      return { recentFolders: [folder, ...filtered].slice(0, 10) };
+    }),
+});

--- a/apps/ui/src/store/types/ui-types.ts
+++ b/apps/ui/src/store/types/ui-types.ts
@@ -117,3 +117,112 @@ export interface KeyboardShortcuts {
   closeTerminal: string;
   newTerminalTab: string;
 }
+
+// Import SidebarStyle from @automaker/types for UI slice
+import type { SidebarStyle } from '@automaker/types';
+
+/**
+ * UI Slice State
+ * Contains all UI-related state that is extracted into the UI slice.
+ */
+export interface UISliceState {
+  // Core UI State
+  currentView: ViewMode;
+  sidebarOpen: boolean;
+  sidebarStyle: SidebarStyle;
+  collapsedNavSections: Record<string, boolean>;
+  mobileSidebarHidden: boolean;
+
+  // Theme State
+  theme: ThemeMode;
+  previewTheme: ThemeMode | null;
+
+  // Font State
+  fontFamilySans: string | null;
+  fontFamilyMono: string | null;
+
+  // Board UI State
+  boardViewMode: BoardViewMode;
+  boardBackgroundByProject: Record<string, BackgroundSettings>;
+
+  // Settings UI State
+  keyboardShortcuts: KeyboardShortcuts;
+  muteDoneSound: boolean;
+  disableSplashScreen: boolean;
+  showQueryDevtools: boolean;
+  chatHistoryOpen: boolean;
+
+  // Panel Visibility State
+  worktreePanelCollapsed: boolean;
+  worktreePanelVisibleByProject: Record<string, boolean>;
+  showInitScriptIndicatorByProject: Record<string, boolean>;
+  autoDismissInitScriptIndicatorByProject: Record<string, boolean>;
+
+  // File Picker UI State
+  lastProjectDir: string;
+  recentFolders: string[];
+}
+
+/**
+ * UI Slice Actions
+ * Contains all UI-related actions that are extracted into the UI slice.
+ */
+export interface UISliceActions {
+  // View Actions
+  setCurrentView: (view: ViewMode) => void;
+  toggleSidebar: () => void;
+  setSidebarOpen: (open: boolean) => void;
+  setSidebarStyle: (style: SidebarStyle) => void;
+  setCollapsedNavSections: (sections: Record<string, boolean>) => void;
+  toggleNavSection: (sectionLabel: string) => void;
+  toggleMobileSidebarHidden: () => void;
+  setMobileSidebarHidden: (hidden: boolean) => void;
+
+  // Theme Actions (Pure UI only - project theme actions stay in main store)
+  setTheme: (theme: ThemeMode) => void;
+  getEffectiveTheme: () => ThemeMode;
+  setPreviewTheme: (theme: ThemeMode | null) => void;
+
+  // Font Actions (Pure UI only - project font actions stay in main store)
+  setFontSans: (fontFamily: string | null) => void;
+  setFontMono: (fontFamily: string | null) => void;
+  getEffectiveFontSans: () => string | null;
+  getEffectiveFontMono: () => string | null;
+
+  // Board View Actions
+  setBoardViewMode: (mode: BoardViewMode) => void;
+  setBoardBackground: (projectPath: string, imagePath: string | null) => void;
+  setCardOpacity: (projectPath: string, opacity: number) => void;
+  setColumnOpacity: (projectPath: string, opacity: number) => void;
+  setColumnBorderEnabled: (projectPath: string, enabled: boolean) => void;
+  setCardGlassmorphism: (projectPath: string, enabled: boolean) => void;
+  setCardBorderEnabled: (projectPath: string, enabled: boolean) => void;
+  setCardBorderOpacity: (projectPath: string, opacity: number) => void;
+  setHideScrollbar: (projectPath: string, hide: boolean) => void;
+  getBoardBackground: (projectPath: string) => BackgroundSettings;
+  clearBoardBackground: (projectPath: string) => void;
+
+  // Settings UI Actions
+  setKeyboardShortcut: (key: keyof KeyboardShortcuts, value: string) => void;
+  setKeyboardShortcuts: (shortcuts: Partial<KeyboardShortcuts>) => void;
+  resetKeyboardShortcuts: () => void;
+  setMuteDoneSound: (muted: boolean) => void;
+  setDisableSplashScreen: (disabled: boolean) => void;
+  setShowQueryDevtools: (show: boolean) => void;
+  setChatHistoryOpen: (open: boolean) => void;
+  toggleChatHistory: () => void;
+
+  // Panel Visibility Actions
+  setWorktreePanelCollapsed: (collapsed: boolean) => void;
+  setWorktreePanelVisible: (projectPath: string, visible: boolean) => void;
+  getWorktreePanelVisible: (projectPath: string) => boolean;
+  setShowInitScriptIndicator: (projectPath: string, visible: boolean) => void;
+  getShowInitScriptIndicator: (projectPath: string) => boolean;
+  setAutoDismissInitScriptIndicator: (projectPath: string, autoDismiss: boolean) => void;
+  getAutoDismissInitScriptIndicator: (projectPath: string) => boolean;
+
+  // File Picker UI Actions
+  setLastProjectDir: (dir: string) => void;
+  setRecentFolders: (folders: string[]) => void;
+  addRecentFolder: (folder: string) => void;
+}


### PR DESCRIPTION
## Summary

- Extract UI-related state and actions from `app-store.ts` into a dedicated UI slice using Zustand slice pattern
- Add `UISliceState` and `UISliceActions` interfaces to `store/types/ui-types.ts`
- First implementation of Zustand slice pattern in the codebase
- Fix pre-existing bug: `fontSans`/`fontMono` → `fontFamilySans`/`fontFamilyMono`
- Maintain backward compatibility through re-exports from `app-store.ts`

## Changes

### New Files Created (`apps/ui/src/store/slices/`)

| File | Contents | Lines |
|------|----------|-------|
| `ui-slice.ts` | createUISlice, initialUIState, UISlice type | 310 |
| `index.ts` | Re-exports UI slice | 1 |

### Files Modified

| File | Changes |
|------|---------|
| `apps/ui/src/store/types/ui-types.ts` | Added `UISliceState` and `UISliceActions` interfaces |
| `apps/ui/src/store/app-store.ts` | Import and spread UI slice, remove duplicate code, fix font property names |

### State Extracted to UI Slice

| Category | Properties |
|----------|------------|
| Core UI | `currentView`, `sidebarOpen`, `sidebarStyle`, `collapsedNavSections`, `mobileSidebarHidden` |
| Theme | `theme`, `previewTheme` |
| Fonts | `fontFamilySans`, `fontFamilyMono` |
| Board UI | `boardViewMode`, `boardBackgroundByProject` |
| Settings UI | `keyboardShortcuts`, `muteDoneSound`, `disableSplashScreen`, `showQueryDevtools`, `chatHistoryOpen` |
| Panel Visibility | `worktreePanelCollapsed`, `worktreePanelVisibleByProject`, `showInitScriptIndicatorByProject`, `autoDismissInitScriptIndicatorByProject` |
| File Picker | `lastProjectDir`, `recentFolders` |

### Actions Extracted to UI Slice

- View: `setCurrentView`, `toggleSidebar`, `setSidebarOpen`, `setSidebarStyle`, `setCollapsedNavSections`, `toggleNavSection`, `toggleMobileSidebarHidden`, `setMobileSidebarHidden`
- Theme: `setTheme`, `getEffectiveTheme`, `setPreviewTheme`
- Fonts: `setFontSans`, `setFontMono`, `getEffectiveFontSans`, `getEffectiveFontMono`
- Board: `setBoardViewMode`, `setBoardBackground`, `setCardOpacity`, `setColumnOpacity`, `setColumnBorderEnabled`, `setCardGlassmorphism`, `setCardBorderEnabled`, `setCardBorderOpacity`, `setHideScrollbar`, `getBoardBackground`, `clearBoardBackground`
- Settings: `setKeyboardShortcut`, `setKeyboardShortcuts`, `resetKeyboardShortcuts`, `setMuteDoneSound`, `setDisableSplashScreen`, `setShowQueryDevtools`, `setChatHistoryOpen`, `toggleChatHistory`
- Panel: `setWorktreePanelCollapsed`, `setWorktreePanelVisible`, `getWorktreePanelVisible`, `setShowInitScriptIndicator`, `getShowInitScriptIndicator`, `setAutoDismissInitScriptIndicator`, `getAutoDismissInitScriptIndicator`
- File Picker: `setLastProjectDir`, `setRecentFolders`, `addRecentFolder`

### Actions Kept in Main Store

These actions modify project entities, not just UI state:
- `setProjectTheme` - modifies `projects[]` and `currentProject`
- `setProjectFontSans` - modifies `projects[]` and `currentProject`
- `setProjectFontMono` - modifies `projects[]` and `currentProject`

### Bug Fix

Fixed pre-existing bug where code accessed `currentProject?.fontSans`/`fontMono` but the `Project` interface has `fontFamilySans`/`fontFamilyMono`.

## Backward Compatibility

All existing imports from `@/store/app-store` continue to work:
```typescript
// These still work
import { useAppStore } from '@/store/app-store';
const { setCurrentView, setBoardViewMode, theme } = useAppStore();
```

New types available:
```typescript
import type { UISliceState, UISliceActions } from '@/store/app-store';
```

## Test Plan

- [x] Build succeeds (`npm run build`)
- [x] Lint passes (`npm run lint` - 0 errors, pre-existing warnings only)
- [x] Package tests pass (`npm run test:packages` - 519 tests)
- [x] Server tests pass (`npm run test:server` - 1,415 tests)

## Manual Testing Before Merge

### View Navigation
- [ ] Navigate between views (Board, Settings, Terminal, Agent, Context, Spec, Ideation)
- [ ] Verify keyboard shortcuts work for navigation (K, S, T, A, C, D, I)

### Sidebar
- [ ] Toggle sidebar visibility with backtick key (`)
- [ ] Collapse/expand nav sections in sidebar
- [ ] Switch sidebar style between 'unified' and 'discord' in settings

### Theme
- [ ] Change global theme in Settings → Appearance
- [ ] Verify theme preview on hover works in theme selector
- [ ] Set per-project theme override and verify it takes effect

### Fonts
- [ ] Change global sans font in Settings → Appearance
- [ ] Change global mono font in Settings → Appearance
- [ ] Set per-project font override and verify it applies

### Board View
- [ ] Switch between Kanban and Graph views (K and H keys)
- [ ] Set a board background image
- [ ] Adjust card opacity, column opacity, glassmorphism settings
- [ ] Clear board background

### Keyboard Shortcuts
- [ ] Modify a keyboard shortcut in Settings → Keyboard Shortcuts
- [ ] Reset keyboard shortcuts to defaults
- [ ] Verify modified shortcut works

### Settings UI
- [ ] Toggle "Mute done sound" setting
- [ ] Toggle "Disable splash screen" setting
- [ ] Toggle "Show Query DevTools" setting (dev mode)

### Panel Visibility
- [ ] Collapse/expand worktree panel in board view
- [ ] Toggle worktree panel row visibility per project
- [ ] Toggle init script indicator visibility per project

### File Picker
- [ ] Open a project and verify recent folders are tracked
- [ ] Verify last project directory is remembered

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal restructuring of application state management to improve code organization and maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->