### PR TITLE
fix: Correct OpenCode dynamic models API endpoint URL

### DIFF
--- a/apps/ui/src/store/app-store.ts
+++ b/apps/ui/src/store/app-store.ts
@@ -2512,7 +2512,7 @@ export const useAppStore = create<AppState & AppActions>()((set, get) => ({
           authMethod?: string;
         }>;
         error?: string;
-      }>('/api/opencode/models');
+      }>('/api/setup/opencode/models');
 
       if (data.success && data.models) {
         // Filter out Bedrock models


### PR DESCRIPTION
## Summary

This PR fixes a bug where enabled OpenCode dynamic models (e.g., local Ollama models) were not appearing in the Model Defaults dropdown selectors.

## Root Cause

The [fetchOpencodeModels](cci:1://file:///Users/ken/Automaker/automaker%20git/apps/ui/src/store/app-store.ts:2472:2-2543:3) function in [apps/ui/src/store/app-store.ts](cci:7://file:///Users/ken/Automaker/automaker%20git/apps/ui/src/store/app-store.ts:0:0-0:0) was calling the wrong API endpoint:

- **Wrong:** `/api/opencode/models` → Returns 404
- **Correct:** `/api/setup/opencode/models` → Returns 200 with dynamic models

The OpenCode Settings page worked correctly because it uses React Query hooks that call the correct endpoint, but the app store's [fetchOpencodeModels](cci:1://file:///Users/ken/Automaker/automaker%20git/apps/ui/src/store/app-store.ts:2472:2-2543:3) function was calling a non-existent endpoint.

## Changes

- Changed API endpoint URL from `/api/opencode/models` to `/api/setup/opencode/models` in the [fetchOpencodeModels](cci:1://file:///Users/ken/Automaker/automaker%20git/apps/ui/src/store/app-store.ts:2472:2-2543:3) function (line 2515)

## Testing

- Verified dynamic models (Ollama local models) now appear in Model Defaults dropdown after enabling them in OpenCode Settings
- Server logs now show `GET /api/setup/opencode/models 200` instead of `GET /api/opencode/models 404`

## Checklist

- [x] Targets the current RC branch (`v0.14.0rc`)
- [x] Clear title describing the change
- [x] All CI checks should pass (single line change, no breaking changes)
- [x] No merge conflicts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal API endpoint for model configuration retrieval.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->