### PR TITLE
fix(ui): handle null selectedWorktree in max concurrency handler

### DIFF
--- a/apps/ui/src/components/views/board-view.tsx
+++ b/apps/ui/src/components/views/board-view.tsx
@@ -1275,10 +1275,9 @@ export function BoardView() {
         runningAgentsCount={runningAutoTasks.length}
         onConcurrencyChange={(newMaxConcurrency) => {
           if (currentProject) {
-            // If selectedWorktree is undefined, fallback to null (main/primary worktree)
-            // Use null for the main worktree, otherwise use the branch name; also null if no worktree selected
-            const branchName =
-              selectedWorktree && !selectedWorktree.isMain ? selectedWorktree.branch : null;
+            // If selectedWorktree is undefined or it's the main worktree, branchName will be null.
+            // Otherwise, use the branch name.
+            const branchName = selectedWorktree?.isMain === false ? selectedWorktree.branch : null;
             setMaxConcurrencyForWorktree(currentProject.id, branchName, newMaxConcurrency);
             // Also update backend if auto mode is running
             if (autoMode.isRunning) {

--- a/apps/ui/src/components/views/board-view.tsx
+++ b/apps/ui/src/components/views/board-view.tsx
@@ -1274,8 +1274,11 @@ export function BoardView() {
         maxConcurrency={maxConcurrency}
         runningAgentsCount={runningAutoTasks.length}
         onConcurrencyChange={(newMaxConcurrency) => {
-          if (currentProject && selectedWorktree) {
-            const branchName = selectedWorktree.isMain ? null : selectedWorktree.branch;
+          if (currentProject) {
+            // If selectedWorktree is undefined, fallback to null (main/primary worktree)
+            // Use null for the main worktree, otherwise use the branch name; also null if no worktree selected
+            const branchName =
+              selectedWorktree && !selectedWorktree.isMain ? selectedWorktree.branch : null;
             setMaxConcurrencyForWorktree(currentProject.id, branchName, newMaxConcurrency);
             // Also update backend if auto mode is running
             if (autoMode.isRunning) {


### PR DESCRIPTION
## Summary

Fixes max concurrency setting not being saved when no worktree is selected (main/primary worktree).

The bug was in the `onConcurrencyChange` handler in `board-view.tsx` which required both `currentProject` AND `selectedWorktree` to be truthy. However, `selectedWorktree` can be `null`/`undefined` when viewing the main worktree, preventing the setting from being saved.

## Related Issue

Closes #719

## Changes

- Changed condition from `if (currentProject && selectedWorktree)` to `if (currentProject)`
- Added explicit null fallback handling for `selectedWorktree`
- Added clarifying comments about the null behavior

## Testing

- [x] Verified max concurrency can be saved when no worktree selected
- [x] Verified max concurrency can still be saved for feature branch worktrees
- [x] Verified auto mode respects the saved setting

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Concurrency settings now apply when a project is open even if no specific worktree is selected.
  * Branch detection improved to treat the main/default worktree distinctly, avoiding incorrect branch assignments.

* **Chores**
  * No public API or exported signatures were changed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->