### PR TITLE
fix: resolve Electron build module resolution for local packages

### DIFF
--- a/apps/ui/scripts/prepare-server.mjs
+++ b/apps/ui/scripts/prepare-server.mjs
@@ -77,16 +77,40 @@ for (const pkgName of LOCAL_PACKAGES) {
   console.log(`   ✓ ${pkgName}`);
 }
 
-// Step 5: Create a minimal package.json for the server
+// Step 5: Create a minimal package.json for the server (without local packages)
+// Also collect external dependencies from local packages
 console.log('📝 Creating server package.json...');
 const serverPkg = JSON.parse(readFileSync(join(SERVER_DIR, 'package.json'), 'utf-8'));
 
-// Replace local package versions with file: references
+// Remove local packages from dependencies - we'll copy them directly to node_modules
+// This avoids symlinks that break in packaged apps
 const dependencies = { ...serverPkg.dependencies };
 for (const pkgName of LOCAL_PACKAGES) {
-  if (dependencies[pkgName]) {
-    const pkgDir = pkgName.replace('@automaker/', '');
-    dependencies[pkgName] = `file:libs/${pkgDir}`;
+  delete dependencies[pkgName];
+}
+
+// Collect external dependencies from local packages
+// These need to be installed via npm since we're copying local packages directly
+console.log('📦 Collecting dependencies from local packages...');
+for (const pkgName of LOCAL_PACKAGES) {
+  const pkgDir = pkgName.replace('@automaker/', '');
+  const pkgJsonPath = join(LIBS_DIR, pkgDir, 'package.json');
+
+  if (existsSync(pkgJsonPath)) {
+    const localPkg = JSON.parse(readFileSync(pkgJsonPath, 'utf-8'));
+    if (localPkg.dependencies) {
+      for (const [depName, depVersion] of Object.entries(localPkg.dependencies)) {
+        // Skip other local packages - they're handled separately
+        if (depName.startsWith('@automaker/')) {
+          continue;
+        }
+        // Add external dependency if not already present
+        if (!dependencies[depName]) {
+          dependencies[depName] = depVersion;
+          console.log(`   + ${depName}@${depVersion} (from ${pkgName})`);
+        }
+      }
+    }
   }
 }
 
@@ -100,8 +124,9 @@ const bundlePkg = {
 
 writeFileSync(join(BUNDLE_DIR, 'package.json'), JSON.stringify(bundlePkg, null, 2));
 
-// Step 6: Install production dependencies
+// Step 6: Install production dependencies (external only)
 console.log('📥 Installing server production dependencies...');
+// Note: execSync is used here with hardcoded commands (no user input) for build automation
 execSync('npm install --omit=dev', {
   cwd: BUNDLE_DIR,
   stdio: 'inherit',
@@ -112,7 +137,27 @@ execSync('npm install --omit=dev', {
   },
 });
 
-// Step 7: Rebuild native modules for current architecture
+// Step 7: Copy local packages directly to node_modules (avoiding symlinks)
+console.log('📦 Installing local packages to node_modules...');
+const nodeModulesAutomaker = join(BUNDLE_DIR, 'node_modules', '@automaker');
+mkdirSync(nodeModulesAutomaker, { recursive: true });
+
+for (const pkgName of LOCAL_PACKAGES) {
+  const pkgDir = pkgName.replace('@automaker/', '');
+  const srcDir = join(bundleLibsDir, pkgDir);
+  const destDir = join(nodeModulesAutomaker, pkgDir);
+
+  if (existsSync(srcDir)) {
+    // Remove any existing symlink or directory
+    if (existsSync(destDir)) {
+      rmSync(destDir, { recursive: true });
+    }
+    cpSync(srcDir, destDir, { recursive: true });
+    console.log(`   ✓ ${pkgName}`);
+  }
+}
+
+// Step 8: Rebuild native modules for current architecture
 // This is critical for modules like node-pty that have native bindings
 console.log('🔨 Rebuilding native modules for current architecture...');
 try {

--- a/libs/platform/src/system-paths.ts
+++ b/libs/platform/src/system-paths.ts
@@ -740,6 +740,7 @@ export function electronUserDataReadFileSync(
 
 /**
  * Write a file to Electron userData directory
+ * Ensures parent directory exists before writing
  */
 export function electronUserDataWriteFileSync(
   relativePath: string,
@@ -750,6 +751,11 @@ export function electronUserDataWriteFileSync(
     throw new Error('[SystemPaths] Electron userData path not initialized');
   }
   const fullPath = path.join(electronUserDataPath, relativePath);
+  // Ensure parent directory exists
+  const parentDir = path.dirname(fullPath);
+  if (!fsSync.existsSync(parentDir)) {
+    fsSync.mkdirSync(parentDir, { recursive: true });
+  }
   fsSync.writeFileSync(fullPath, data, options);
 }
 


### PR DESCRIPTION
## Summary

- **Fix local package bundling**: Replaced `file:` references (which create symlinks) with direct copying of `@automaker/*` packages to `node_modules`, resolving `ERR_MODULE_NOT_FOUND` errors in packaged Electron apps (AppImage, deb)
- **Collect transitive dependencies**: External dependencies of local packages (e.g. `p-limit` from `@automaker/platform`) are now collected and installed via npm
- **Fix first-launch ENOENT**: Ensure parent directories exist before writing to Electron `userData`, preventing crashes on first app launch

## Test plan

- [ ] Run `npm run build:electron:linux` (or mac/win equivalent) — build should complete without errors
- [ ] Launch the built AppImage/installer — server should start without module resolution errors
- [ ] Verify first launch works on a clean system (no `~/.config/Automaker/` directory)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced file system operations to automatically ensure parent directories exist before writing files, preventing potential failures.

* **Chores**
  * Optimized build and server preparation processes to streamline local package handling and reduce symlink dependencies for improved deployment reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->