### PR TITLE
fix(docker): add missing spec-parser package.json to base stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,7 @@ COPY libs/platform/package*.json ./libs/platform/
 COPY libs/model-resolver/package*.json ./libs/model-resolver/
 COPY libs/dependency-resolver/package*.json ./libs/dependency-resolver/
 COPY libs/git-utils/package*.json ./libs/git-utils/
+COPY libs/spec-parser/package*.json ./libs/spec-parser/
 
 # Copy scripts (needed by npm workspace)
 COPY scripts ./scripts


### PR DESCRIPTION
## Summary

Fixes Docker build failure caused by missing `@automaker/spec-parser` package.json in the Dockerfile's BASE stage.

## Problem

When building the Docker image, `npm ci` fails with:

```
Cannot find module 'fast-xml-parser'
```

This occurs because `@automaker/spec-parser` was added to the monorepo but its `package.json` was not included in the Dockerfile's BASE stage COPY instructions.

## Solution

Add the missing COPY instruction for `libs/spec-parser/package*.json` alongside the other library package files.

## Changes

- `Dockerfile`: Add `COPY libs/spec-parser/package*.json ./libs/spec-parser/` to BASE stage

## Testing

- [x] Docker build completes successfully
- [x] Server starts and runs correctly in container

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to ensure consistent handling of dependency files across build stages.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->