### PR TITLE
fix(server): handle Express 5 req.params type union

### DIFF
--- a/apps/server/src/routes/sessions/routes/archive.ts
+++ b/apps/server/src/routes/sessions/routes/archive.ts
@@ -9,7 +9,7 @@ import { getErrorMessage, logError } from '../common.js';
 export function createArchiveHandler(agentService: AgentService) {
   return async (req: Request, res: Response): Promise<void> => {
     try {
-      const { sessionId } = req.params;
+      const sessionId = req.params.sessionId as string;
       const success = await agentService.archiveSession(sessionId);
 
       if (!success) {

--- a/apps/server/src/routes/sessions/routes/delete.ts
+++ b/apps/server/src/routes/sessions/routes/delete.ts
@@ -9,7 +9,7 @@ import { getErrorMessage, logError } from '../common.js';
 export function createDeleteHandler(agentService: AgentService) {
   return async (req: Request, res: Response): Promise<void> => {
     try {
-      const { sessionId } = req.params;
+      const sessionId = req.params.sessionId as string;
       const success = await agentService.deleteSession(sessionId);
 
       if (!success) {

--- a/apps/server/src/routes/sessions/routes/unarchive.ts
+++ b/apps/server/src/routes/sessions/routes/unarchive.ts
@@ -9,7 +9,7 @@ import { getErrorMessage, logError } from '../common.js';
 export function createUnarchiveHandler(agentService: AgentService) {
   return async (req: Request, res: Response): Promise<void> => {
     try {
-      const { sessionId } = req.params;
+      const sessionId = req.params.sessionId as string;
       const success = await agentService.unarchiveSession(sessionId);
 
       if (!success) {

--- a/apps/server/src/routes/sessions/routes/update.ts
+++ b/apps/server/src/routes/sessions/routes/update.ts
@@ -9,7 +9,7 @@ import { getErrorMessage, logError } from '../common.js';
 export function createUpdateHandler(agentService: AgentService) {
   return async (req: Request, res: Response): Promise<void> => {
     try {
-      const { sessionId } = req.params;
+      const sessionId = req.params.sessionId as string;
       const { name, tags, model } = req.body as {
         name?: string;
         tags?: string[];

--- a/apps/server/src/routes/terminal/routes/session-delete.ts
+++ b/apps/server/src/routes/terminal/routes/session-delete.ts
@@ -8,7 +8,7 @@ import { getTerminalService } from '../../../services/terminal-service.js';
 export function createSessionDeleteHandler() {
   return (req: Request, res: Response): void => {
     const terminalService = getTerminalService();
-    const { id } = req.params;
+    const id = req.params.id as string;
     const killed = terminalService.killSession(id);
 
     if (!killed) {

--- a/apps/server/src/routes/terminal/routes/session-resize.ts
+++ b/apps/server/src/routes/terminal/routes/session-resize.ts
@@ -8,7 +8,7 @@ import { getTerminalService } from '../../../services/terminal-service.js';
 export function createSessionResizeHandler() {
   return (req: Request, res: Response): void => {
     const terminalService = getTerminalService();
-    const { id } = req.params;
+    const id = req.params.id as string;
     const { cols, rows } = req.body;
 
     if (!cols || !rows) {


### PR DESCRIPTION
## Summary

Fixes TypeScript compilation errors caused by Express 5's changed `req.params` type signature.

## Problem

Express 5 changed `req.params` values from `string` to `string | string[]` to support array parameter patterns (`:param+`, `:param*`). This causes TypeScript errors:

```
Type 'string | string[]' is not assignable to parameter of type 'string'.
  Type 'string[]' is not assignable to type 'string'.
```

## Solution

Explicitly access and assert the parameter type instead of using object destructuring:

```typescript
// Before (fails with Express 5 types)
const { sessionId } = req.params;

// After (works with Express 5 types)
const sessionId = req.params.sessionId as string;
```

This is safe because these routes use simple `:param` patterns, not array patterns.

## Changes

- `apps/server/src/routes/sessions/routes/archive.ts`
- `apps/server/src/routes/sessions/routes/delete.ts`
- `apps/server/src/routes/sessions/routes/unarchive.ts`
- `apps/server/src/routes/sessions/routes/update.ts`
- `apps/server/src/routes/terminal/routes/session-delete.ts`
- `apps/server/src/routes/terminal/routes/session-resize.ts`

## Testing

- [x] TypeScript compiles without errors
- [x] Server builds successfully
- [x] Routes function correctly at runtime

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal type safety in request parameter handling for session and terminal routes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->