### PR TITLE
fix(ui): prevent Vite tree-shaking of web mode API URL detection

### DIFF
--- a/apps/ui/src/lib/http-api-client.ts
+++ b/apps/ui/src/lib/http-api-client.ts
@@ -157,9 +157,12 @@ const getServerUrl = (): string => {
     const envUrl = import.meta.env.VITE_SERVER_URL;
     if (envUrl) return envUrl;
 
-    // In web mode (not Electron), use relative URL to leverage Vite proxy
+    // In web mode (not Electron), use relative URL to leverage nginx proxy
     // This avoids CORS issues since requests appear same-origin
-    if (!window.electron) {
+    // Note: Using 'in' operator prevents Vite from tree-shaking this branch,
+    // as it cannot statically determine the result at build time
+    const isElectron = 'electron' in window && window.electron != null;
+    if (!isElectron) {
       return '';
     }
   }


### PR DESCRIPTION
## Summary

Fixes Docker web deployments where the UI cannot connect to the backend API.

## Problem

When accessing AutoMaker via browser in Docker deployment, all API requests fail with CORS errors:

```
Cross-Origin Request Blocked: ... at http://localhost:3008/api/...
```

The UI is trying to reach `localhost:3008` which, from the user's browser, refers to their local machine - not the Docker container.

### Root Cause

The `getServerUrl()` function has web mode detection:

```typescript
if (!window.electron) {
  return '';  // Use relative URLs in web mode
}
```

However, Vite's tree-shaking evaluates `!window.electron` as `true` during build (since `window.electron` is undefined in the build environment) and removes this branch entirely. The production bundle becomes:

```javascript
O1=()=>mT||"http://localhost:3008"  // Always falls back to localhost
```

## Solution

Use the `in` operator which Vite cannot statically analyze:

```typescript
const isElectron = 'electron' in window && window.electron != null;
if (!isElectron) {
  return '';
}
```

This preserves the runtime check in the production bundle, allowing web mode to use relative URLs (`/api/...`) that nginx can proxy to the backend.

## Docker Deployment Note

For Docker web deployments to work, nginx must proxy `/api/` requests to the backend. The UI's `docker-compose.yml` should include nginx configuration like:

```nginx
location /api/ {
    proxy_pass http://automaker-server:3008;
    proxy_http_version 1.1;
    proxy_set_header Upgrade $http_upgrade;
    proxy_set_header Connection "upgrade";
}
```

## Changes

- `apps/ui/src/lib/http-api-client.ts`: Use `in` operator for Electron detection

## Testing

- [x] Production build preserves web mode detection
- [x] Docker web UI connects to API via nginx proxy
- [x] Electron mode continues to work correctly