### PR TITLE
fix(server): Use 'main' as default branch for new git projects

### DIFF
--- a/apps/server/src/routes/worktree/routes/init-git.ts
+++ b/apps/server/src/routes/worktree/routes/init-git.ts
@@ -43,10 +43,14 @@ export function createInitGitHandler() {
         // .git doesn't exist, continue with initialization
       }
 
-      // Initialize git and create an initial empty commit
-      await execAsync(`git init && git commit --allow-empty -m "Initial commit"`, {
-        cwd: projectPath,
-      });
+      // Initialize git with 'main' as the default branch (matching GitHub's standard since 2020)
+      // and create an initial empty commit
+      await execAsync(
+        `git init --initial-branch=main && git commit --allow-empty -m "Initial commit"`,
+        {
+          cwd: projectPath,
+        }
+      );
 
       res.json({
         success: true,

--- a/apps/server/tests/integration/helpers/git-test-repo.ts
+++ b/apps/server/tests/integration/helpers/git-test-repo.ts
@@ -20,8 +20,8 @@ export interface TestRepo {
 export async function createTestGitRepo(): Promise<TestRepo> {
   const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'automaker-test-'));
 
-  // Initialize git repo
-  await execAsync('git init', { cwd: tmpDir });
+  // Initialize git repo with 'main' as the default branch (matching GitHub's standard)
+  await execAsync('git init --initial-branch=main', { cwd: tmpDir });
 
   // Use environment variables instead of git config to avoid affecting user's git config
   // These env vars override git config without modifying it
@@ -37,9 +37,6 @@ export async function createTestGitRepo(): Promise<TestRepo> {
   await fs.writeFile(path.join(tmpDir, 'README.md'), '# Test Project\n');
   await execAsync('git add .', { cwd: tmpDir, env: gitEnv });
   await execAsync('git commit -m "Initial commit"', { cwd: tmpDir, env: gitEnv });
-
-  // Create main branch explicitly
-  await execAsync('git branch -M main', { cwd: tmpDir });
 
   return {
     path: tmpDir,

--- a/apps/server/tests/integration/routes/worktree/create.integration.test.ts
+++ b/apps/server/tests/integration/routes/worktree/create.integration.test.ts
@@ -14,7 +14,8 @@ describe('worktree create route - repositories without commits', () => {
 
   async function initRepoWithoutCommit() {
     repoPath = await fs.mkdtemp(path.join(os.tmpdir(), 'automaker-no-commit-'));
-    await execAsync('git init', { cwd: repoPath });
+    // Initialize with 'main' as the default branch (matching GitHub's standard)
+    await execAsync('git init --initial-branch=main', { cwd: repoPath });
     // Don't set git config - use environment variables in commit operations instead
     // to avoid affecting user's git config
     // Intentionally skip creating an initial commit


### PR DESCRIPTION
Git initialization now explicitly specifies --initial-branch=main to match GitHub's default branch standard (since October 2020). This prevents the branch name mismatch that caused features to disappear from the UI when pushing to GitHub.

Fixes #734


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Git repositories now initialize with 'main' as the default branch name, ensuring consistency across repository creation and initialization workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->