### PR TITLE
fix(platform): add scoop paths for codex cli detection on windows

### DIFF
--- a/libs/platform/src/system-paths.ts
+++ b/libs/platform/src/system-paths.ts
@@ -141,6 +141,14 @@ export function getCodexCliPaths(): string[] {
       // pnpm on Windows
       path.join(localAppData, 'pnpm', 'codex.cmd'),
       path.join(localAppData, 'pnpm', 'codex'),
+      // Scoop Node.js (global packages)
+      path.join(homeDir, 'scoop', 'apps', 'nodejs', 'current', 'bin', 'codex.cmd'),
+      path.join(homeDir, 'scoop', 'apps', 'nodejs', 'current', 'bin', 'codex'),
+      path.join(homeDir, 'scoop', 'apps', 'nodejs', 'current', 'codex.cmd'),
+      path.join(homeDir, 'scoop', 'apps', 'nodejs', 'current', 'codex'),
+      // Scoop global shim
+      path.join(homeDir, 'scoop', 'shims', 'codex.cmd'),
+      path.join(homeDir, 'scoop', 'shims', 'codex'),
     ];
   }
 


### PR DESCRIPTION
This PR adds support for detecting the Codex CLI when installed via Scoop (Windows). It includes paths for Scoop's Node.js current bin directory and global shims.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of CLI tool installations on Windows systems using Scoop package manager, including standard and shimmed entry points.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->