### PR TITLE
fix(docker): Add @playwright/test to server devDependencies

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -43,6 +43,7 @@
     "ws": "8.18.3"
   },
   "devDependencies": {
+    "@playwright/test": "1.57.0",
     "@types/cookie": "0.6.0",
     "@types/cookie-parser": "1.4.10",
     "@types/cors": "2.8.19",


### PR DESCRIPTION
## Summary

This PR fixes an issue discovered while testing #745 (Pre-install Playwright Chromium browsers).

The Dockerfile's playwright install step fails because `@playwright/test` is only in the UI's devDependencies, not the server's. When the Docker build runs:

```dockerfile
COPY --from=server-builder /app/node_modules ./node_modules
RUN ./node_modules/.bin/playwright install chromium
```

The `server-builder` stage only installs server dependencies, so `playwright` isn't in `node_modules/.bin/`.

## Changes

- Added `@playwright/test: 1.57.0` to `apps/server/package.json` devDependencies (matches UI version)

## Testing

1. Built Docker image with `docker compose build --no-cache`
2. Verified playwright installs successfully:
   ```
   Chromium Headless Shell 143.0.7499.4 (playwright build v1200) downloaded to /home/automaker/.cache/ms-playwright/chromium_headless_shell-1200
   === Playwright Chromium installed ===
   ```
3. Tested Automaker's Playwright verification feature end-to-end - working correctly

## Related

- Fixes the build issue in #745
- Can be merged independently or incorporated into #745

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->