### PR TITLE
fix: Enable launcher script to work from any directory via symlink

### DIFF
--- a/start-automaker.sh
+++ b/start-automaker.sh
@@ -9,7 +9,6 @@ set -e
 # ============================================================================
 # CONFIGURATION & CONSTANTS
 # ============================================================================
-APP_NAME="Automaker"
 # Resolve script directory, following symlinks
 SOURCE="${BASH_SOURCE[0]}"
 while [ -L "$SOURCE" ]; do
@@ -17,6 +16,13 @@ while [ -L "$SOURCE" ]; do
     SOURCE="$(readlink "$SOURCE")"
     [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE"
 done
+
+# Verify the resolved script exists (detect broken symlinks)
+if [ ! -f "$SOURCE" ]; then
+    echo "Error: Script file not found after resolving symlinks: $SOURCE" >&2
+    exit 1
+fi
+
 SCRIPT_DIR="$(cd -P "$(dirname "$SOURCE")" && pwd)"
 
 # Change to project directory so all relative paths work


### PR DESCRIPTION
## Summary

This PR fixes the launcher script (`start-automaker.sh`) to work correctly when called from any directory, particularly when accessed via a symlink (e.g., `~/.local/bin/automaker`).

### Changes

- **Symlink resolution**: Added logic to follow symlinks to find the actual script location
- **Directory change**: Script now changes to the project directory before executing
- **Improved .env loading**: Moved `.env` loading to after directory change to ensure it finds the file correctly
- **Removed duplicate**: Cleaned up duplicate `.env` loading in web mode (now loaded once at the top)

### Problem Solved

Previously, when users created a symlink like `~/.local/bin/automaker -> /path/to/automaker/start-automaker.sh`, running `automaker` from any directory would fail because:
1. `SCRIPT_DIR` would resolve to the symlink location (`~/.local/bin/`) instead of the actual project directory
2. Relative paths (`.env`, `package.json`, npm commands) would fail

### Testing

- [x] Tested running script directly from project directory
- [x] Tested running script via symlink from different directories
- [x] Verified `.env` file is loaded correctly
- [x] Confirmed version command works: `automaker --version`

### Example Usage

```bash
# Create symlink (one-time setup)
ln -s /path/to/automaker/start-automaker.sh ~/.local/bin/automaker

# Now works from any directory
cd /tmp
automaker --version  # ✅ Works!
automaker            # ✅ Launches correctly!
```

## Related Issue

Fixes the issue where the launcher script depends on being run from the project directory.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved startup reliability with robust path resolution and streamlined initialization to handle different execution contexts.
  * Ensured environment configuration is loaded earlier and more consistently during startup, reducing startup errors and simplifying runtime behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->