### PR TITLE
chore: bump version to 0.14.0

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automaker/server",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Backend server for Automaker - provides API for both web and Electron modes",
   "author": "AutoMaker Team",
   "license": "SEE LICENSE IN LICENSE",

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automaker/ui",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "An autonomous AI development studio that helps you build software faster using AI-powered agents",
   "homepage": "https://github.com/AutoMaker-Org/automaker",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "automaker",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "license": "MIT",
   "private": true,
   "engines": {


### PR DESCRIPTION
## Summary
- Bumps `version` in `package.json`, `apps/ui/package.json`, and `apps/server/package.json` from `0.13.0` to `0.14.0`
- The v0.14.0 release was tagged without updating these version strings

## Test plan
- [ ] Verify `automaker --version` reports 0.14.0 after install

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 0.14.0 across all packages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->