### PR TITLE
Preserve pipeline work by using waiting_approval on post-completion errors

### DIFF
--- a/apps/server/src/services/execution-service.ts
+++ b/apps/server/src/services/execution-service.ts
@@ -557,8 +557,12 @@ Please continue from where you left off and complete all remaining tasks. Use th
         try {
           const currentFeature = await this.loadFeatureFn(projectPath, featureId);
           currentStatus = currentFeature?.status;
-        } catch {
-          // If loading fails, proceed with the status update anyway
+        } catch (loadErr) {
+          // If loading fails, log it and proceed with the status update anyway
+          logger.warn(
+            `[executeFeature] Failed to reload feature ${featureId} for status check:`,
+            loadErr
+          );
         }
         if (currentStatus !== 'merge_conflict') {
           await this.updateFeatureStatusFn(projectPath, featureId, fallbackStatus);

--- a/apps/server/src/services/execution-service.ts
+++ b/apps/server/src/services/execution-service.ts
@@ -179,6 +179,7 @@ ${feature.spec}
     const abortController = tempRunningFeature.abortController;
     if (isAutoMode) await this.saveExecutionStateFn(projectPath);
     let feature: Feature | null = null;
+    let pipelineCompleted = false;
 
     try {
       validateWorkingDirectory(projectPath);
@@ -431,6 +432,7 @@ Please continue from where you left off and complete all remaining tasks. Use th
           testAttempts: 0,
           maxTestAttempts: 5,
         });
+        pipelineCompleted = true;
         // Check if pipeline set a terminal status (e.g., merge_conflict) — don't overwrite it
         const refreshed = await this.loadFeatureFn(projectPath, featureId);
         if (refreshed?.status === 'merge_conflict') {
@@ -541,7 +543,16 @@ Please continue from where you left off and complete all remaining tasks. Use th
         }
       } else {
         logger.error(`Feature ${featureId} failed:`, error);
-        await this.updateFeatureStatusFn(projectPath, featureId, 'backlog');
+        // If pipeline steps completed successfully, don't send the feature back to backlog.
+        // The pipeline work is done — set to waiting_approval so the user can review.
+        const fallbackStatus = pipelineCompleted ? 'waiting_approval' : 'backlog';
+        if (pipelineCompleted) {
+          logger.info(
+            `[executeFeature] Feature ${featureId} failed after pipeline completed. ` +
+              `Setting status to waiting_approval instead of backlog to preserve pipeline work.`
+          );
+        }
+        await this.updateFeatureStatusFn(projectPath, featureId, fallbackStatus);
         this.eventBus.emitAutoModeEvent('auto_mode_error', {
           featureId,
           featureName: feature?.title,

--- a/apps/server/src/services/execution-service.ts
+++ b/apps/server/src/services/execution-service.ts
@@ -552,7 +552,11 @@ Please continue from where you left off and complete all remaining tasks. Use th
               `Setting status to waiting_approval instead of backlog to preserve pipeline work.`
           );
         }
-        await this.updateFeatureStatusFn(projectPath, featureId, fallbackStatus);
+        // Don't overwrite terminal states like 'merge_conflict' that were set during pipeline execution
+        const currentFeature = await this.loadFeatureFn(projectPath, featureId);
+        if (currentFeature?.status !== 'merge_conflict') {
+          await this.updateFeatureStatusFn(projectPath, featureId, fallbackStatus);
+        }
         this.eventBus.emitAutoModeEvent('auto_mode_error', {
           featureId,
           featureName: feature?.title,

--- a/apps/server/src/services/execution-service.ts
+++ b/apps/server/src/services/execution-service.ts
@@ -553,8 +553,14 @@ Please continue from where you left off and complete all remaining tasks. Use th
           );
         }
         // Don't overwrite terminal states like 'merge_conflict' that were set during pipeline execution
-        const currentFeature = await this.loadFeatureFn(projectPath, featureId);
-        if (currentFeature?.status !== 'merge_conflict') {
+        let currentStatus: string | undefined;
+        try {
+          const currentFeature = await this.loadFeatureFn(projectPath, featureId);
+          currentStatus = currentFeature?.status;
+        } catch {
+          // If loading fails, proceed with the status update anyway
+        }
+        if (currentStatus !== 'merge_conflict') {
           await this.updateFeatureStatusFn(projectPath, featureId, fallbackStatus);
         }
         this.eventBus.emitAutoModeEvent('auto_mode_error', {

--- a/apps/server/src/services/pipeline-orchestrator.ts
+++ b/apps/server/src/services/pipeline-orchestrator.ts
@@ -350,6 +350,7 @@ export class PipelineOrchestrator {
     });
     const abortController = runningEntry.abortController;
     runningEntry.branchName = feature.branchName ?? null;
+    let pipelineCompleted = false;
 
     try {
       validateWorkingDirectory(projectPath);
@@ -403,6 +404,7 @@ export class PipelineOrchestrator {
       };
 
       await this.executePipeline(context);
+      pipelineCompleted = true;
 
       // Re-fetch feature to check if executePipeline set a terminal status (e.g., merge_conflict)
       const reloadedFeature = await this.featureStateManager.loadFeature(projectPath, featureId);
@@ -439,8 +441,17 @@ export class PipelineOrchestrator {
           });
         }
       } else {
+        // If pipeline steps completed successfully, don't send the feature back to backlog.
+        // The pipeline work is done — set to waiting_approval so the user can review.
+        const fallbackStatus = pipelineCompleted ? 'waiting_approval' : 'backlog';
+        if (pipelineCompleted) {
+          logger.info(
+            `[resumeFromStep] Feature ${featureId} failed after pipeline completed. ` +
+              `Setting status to waiting_approval instead of backlog to preserve pipeline work.`
+          );
+        }
         logger.error(`Pipeline resume failed for ${featureId}:`, error);
-        await this.updateFeatureStatusFn(projectPath, featureId, 'backlog');
+        await this.updateFeatureStatusFn(projectPath, featureId, fallbackStatus);
         this.eventBus.emitAutoModeEvent('auto_mode_error', {
           featureId,
           featureName: feature.title,

--- a/apps/server/src/services/pipeline-orchestrator.ts
+++ b/apps/server/src/services/pipeline-orchestrator.ts
@@ -451,7 +451,11 @@ export class PipelineOrchestrator {
           );
         }
         logger.error(`Pipeline resume failed for ${featureId}:`, error);
-        await this.updateFeatureStatusFn(projectPath, featureId, fallbackStatus);
+        // Don't overwrite terminal states like 'merge_conflict' that were set during pipeline execution
+        const currentFeature = await this.featureStateManager.loadFeature(projectPath, featureId);
+        if (currentFeature?.status !== 'merge_conflict') {
+          await this.updateFeatureStatusFn(projectPath, featureId, fallbackStatus);
+        }
         this.eventBus.emitAutoModeEvent('auto_mode_error', {
           featureId,
           featureName: feature.title,

--- a/apps/server/tests/unit/services/execution-service.test.ts
+++ b/apps/server/tests/unit/services/execution-service.test.ts
@@ -2000,5 +2000,60 @@ describe('execution-service.ts', () => {
       // The only non-in_progress status call should be absent since merge_conflict returns early
       expect(statusCalls.length).toBe(0);
     });
+
+    it('sets waiting_approval instead of backlog when error occurs after pipeline completes', async () => {
+      // Set up pipeline with steps
+      vi.mocked(pipelineService.getPipelineConfig).mockResolvedValue({
+        version: 1,
+        steps: [{ id: 'step-1', name: 'Step 1', order: 1, instructions: 'Do step 1' }] as any,
+      });
+
+      // Pipeline succeeds, but reading agent output throws after pipeline completes
+      mockExecutePipelineFn = vi.fn().mockResolvedValue(undefined);
+      // Simulate an error after pipeline completes by making loadFeature throw
+      // on the post-pipeline refresh call
+      let loadCallCount = 0;
+      mockLoadFeatureFn = vi.fn().mockImplementation(() => {
+        loadCallCount++;
+        if (loadCallCount === 1) return testFeature; // initial load
+        // Second call is the task-retry check, third is the pipeline refresh
+        if (loadCallCount <= 2) return testFeature;
+        throw new Error('Unexpected post-pipeline error');
+      });
+
+      const svc = createServiceWithMocks();
+      await svc.executeFeature('/test/project', 'feature-1');
+
+      // Should set to waiting_approval, NOT backlog, since pipeline completed
+      const backlogCalls = vi
+        .mocked(mockUpdateFeatureStatusFn)
+        .mock.calls.filter((call) => call[2] === 'backlog');
+      expect(backlogCalls.length).toBe(0);
+
+      const waitingCalls = vi
+        .mocked(mockUpdateFeatureStatusFn)
+        .mock.calls.filter((call) => call[2] === 'waiting_approval');
+      expect(waitingCalls.length).toBeGreaterThan(0);
+    });
+
+    it('still sets backlog when error occurs before pipeline completes', async () => {
+      // Set up pipeline with steps
+      vi.mocked(pipelineService.getPipelineConfig).mockResolvedValue({
+        version: 1,
+        steps: [{ id: 'step-1', name: 'Step 1', order: 1, instructions: 'Do step 1' }] as any,
+      });
+
+      // Pipeline itself throws (e.g., agent error during pipeline step)
+      mockExecutePipelineFn = vi.fn().mockRejectedValue(new Error('Agent execution failed'));
+
+      const svc = createServiceWithMocks();
+      await svc.executeFeature('/test/project', 'feature-1');
+
+      // Should still set to backlog since pipeline did NOT complete
+      const backlogCalls = vi
+        .mocked(mockUpdateFeatureStatusFn)
+        .mock.calls.filter((call) => call[2] === 'backlog');
+      expect(backlogCalls.length).toBe(1);
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Track pipeline completion state and use `waiting_approval` instead of `backlog` when errors occur after pipeline steps finish
- Prevents loss of completed pipeline work when post-completion operations fail
- Applies to both normal execution and resume-from-step code paths

## Changes
- **execution-service.ts**: Added `pipelineCompleted` flag to track successful pipeline execution. When a post-pipeline error occurs, set feature status to `waiting_approval` instead of `backlog` to preserve the completed work.
- **pipeline-orchestrator.ts**: Added `pipelineCompleted` flag in the resume path with the same logic to maintain consistency across both execution flows.
- **execution-service.test.ts**: Added two test cases to verify the new behavior:
  - Confirms `waiting_approval` is used when errors occur after pipeline completion
  - Confirms `backlog` is still used when errors occur during pipeline execution itself

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved post-pipeline error handling: if an error occurs after pipeline steps finish, feature status now moves to "waiting for approval" (preserving completed work) instead of reverting to "backlog"; terminal states like "merge_conflict" are preserved and not overwritten.

* **Tests**
  * Added unit tests verifying status transitions for errors occurring both before and after pipeline completion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->